### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Marketplace](https://img.shields.io/vscode-marketplace/v/IBM.codewind.svg?label=marketplace&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=IBM.codewind)
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
-[![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=5dbf5d)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
+[![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=145dbf)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
 
 # Codewind for VS Code
 Create and develop cloud-native, containerized web applications from VS Code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Marketplace](https://img.shields.io/vscode-marketplace/v/IBM.codewind.svg?label=marketplace&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=IBM.codewind)
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
-[![Slack](https://img.shields.io/badge/ibm--cloud--tech-blue.svg?logo=slack&label=slack)](https://slack-invite-ibm-cloud-tech.mybluemix.net/)
+[![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=5dbf5d)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
 
 # Codewind for VS Code
 Create and develop cloud-native, containerized web applications from VS Code.

--- a/dev/src/codewind/project/ProjectOverviewPage.ts
+++ b/dev/src/codewind/project/ProjectOverviewPage.ts
@@ -239,7 +239,7 @@ function buildDebugSection(project: Project): string {
         ${buildRow("Internal Debug Port",
             normalize(project.ports.internalDebugPort, NOT_AVAILABLE),
             undefined, true)}
-        ${buildRow("Debug URL", normalize(project.debugUrl, NOT_DEBUGGING))}
         </table>
     `;
+        // ${buildRow("Debug URL", normalize(project.debugUrl, NOT_DEBUGGING))}
 }

--- a/dev/src/codewind/project/ProjectType.ts
+++ b/dev/src/codewind/project/ProjectType.ts
@@ -26,7 +26,7 @@ export class ProjectType {
         public readonly language: string,
         public readonly extensionName?: string,
     ) {
-        this.type = ProjectType.getType(internalType, language, extensionName);
+        this.type = ProjectType.getType(internalType, extensionName);
         // this.userFriendlyType = ProjectType.getUserFriendlyType(this.type);
         this.debugType = ProjectType.getDebugType(this.type, language);
         this.icon = ProjectType.getProjectIcon(this.type, language);
@@ -43,7 +43,7 @@ export class ProjectType {
         return this.type.toString();
     }
 
-    private static getType(internalType: string, language: string, extensionName: OptionalString): ProjectType.Types {
+    private static getType(internalType: string, extensionName: OptionalString): ProjectType.Types {
         if (internalType === this.InternalTypes.MICROPROFILE) {
             return ProjectType.Types.MICROPROFILE;
         }
@@ -57,15 +57,7 @@ export class ProjectType {
             return ProjectType.Types.SWIFT;
         }
         else if (internalType === this.InternalTypes.DOCKER) {
-            if (language === this.Languages.PYTHON) {
-                return ProjectType.Types.PYTHON;
-            }
-            else if (language === this.Languages.GO) {
-                return ProjectType.Types.GO;
-            }
-            else {
-                return ProjectType.Types.GENERIC_DOCKER;
-            }
+            return ProjectType.Types.GENERIC_DOCKER;
         }
         else if (extensionName) {
             return ProjectType.Types.EXTENSION;
@@ -147,15 +139,14 @@ export class ProjectType {
 
 export namespace ProjectType {
 
-    // These are the project types as exposed to the user.
-    // String value must be user-friendly!
+    /*
+     * These are the project types as exposed to the user. String value must be user-friendly.
+     */
     export enum Types {
         MICROPROFILE = "Microprofile",
         SPRING = "Spring",
         NODE = "Node.js",
         SWIFT = "Swift",
-        PYTHON = "Python",
-        GO = "Go",
         GENERIC_DOCKER = "Docker",
         EXTENSION = "Extension",
         UNKNOWN = "Unknown"
@@ -163,7 +154,9 @@ export namespace ProjectType {
 
     // non-nls-section-start
 
-    // possible values of the "projectType" or "buildType" internal attribute
+    /**
+     * Possible values of the "projectType" or "buildType" internal attribute
+     */
     export enum InternalTypes {
         MICROPROFILE = "liberty",
         SPRING = "spring",
@@ -172,8 +165,11 @@ export namespace ProjectType {
         DOCKER = "docker"
     }
 
-    // Possible values of the "language" internal attribute
-    // could be others, but if they're not in this list we'll just treat them as generic docker
+
+    /**
+     * Some possible values of the "language" internal attribute, for which we have special treatment such as nicer icons.
+     * Language can be user-determined so this is not a complete list
+     */
     export enum Languages {
         JAVA = "java",
         NODE = "nodejs",
@@ -182,7 +178,9 @@ export namespace ProjectType {
         GO = "go"
     }
 
-    // VSCode debug types, used as the "type" attribute in a debug launch.
+    /**
+     * VSCode debug types, used as the "type" attribute in a debug launch.
+     */
     export enum DebugTypes {
         JAVA = "java",
         NODE = "node"

--- a/dev/src/command/project/ContainerShellCmd.ts
+++ b/dev/src/command/project/ContainerShellCmd.ts
@@ -22,9 +22,13 @@ export default async function containerShellCmd(project: Project): Promise<void>
         return;
     }
 
-    // annoyingly, only python project containers seem to not have bash installed.
-    // TODO We could check what's installed by doing docker exec through child_process, if that's worth the trouble.
-    const toExec: string = project.type.type === ProjectType.Types.PYTHON ? "sh" : "bash";      // non-nls
+    // This is a hack for the python template project not having bash installed.
+    // This would trigger for a user python template too. :(
+    const toExec: string =
+        project.type.type === ProjectType.Types.GENERIC_DOCKER &&
+        project.type.language === ProjectType.Languages.PYTHON ?
+        "sh" : "bash";      // non-nls
+
     // const env = convertNodeEnvToTerminalEnv(process.env);
 
     const options: vscode.TerminalOptions = {


### PR DESCRIPTION
- remove python/go project types that are no longer needed
- remove debug url from overview
- replace slack link with mattermost