### PR TITLE
Trivial - fix incorrect field name.

### DIFF
--- a/dev/src/codewind/connection/SocketEvents.ts
+++ b/dev/src/codewind/connection/SocketEvents.ts
@@ -117,7 +117,7 @@ export interface ILogResponse {
 
 export interface ILogObject {
     readonly logName: string;
-    readonly workspathLogPath?: string;
+    readonly workspaceLogPath?: string;
 }
 
 export default SocketEvents;

--- a/dev/src/codewind/project/logs/MCLogManager.ts
+++ b/dev/src/codewind/project/logs/MCLogManager.ts
@@ -71,7 +71,7 @@ export default class MCLogManager {
                 existingLog.destroy();
             }
 
-            const newLog = new MCLog(this.project.name, newLogData.logName, newLogData.workspathLogPath);
+            const newLog = new MCLog(this.project.name, newLogData.logName, newLogData.workspaceLogPath);
             this.logs.push(newLog);
             if (openOnCreate) {
                 newLog.showOutput();


### PR DESCRIPTION
This PR changes workspathLogPath to workspaceLogPath.
This matches the field name in the socket message being recieived:
https://github.com/eclipse/codewind/blob/deebc7bdf94d8a27f8ff1756e7ba63c6030d87c8/src/pfe/portal/modules/FileWatcher.js#L157-L158

At the moment the value doesn't seem to be displayed so this won't have much impact.