### PR TITLE
Upload on remote build request

### DIFF
--- a/dev/src/codewind/connection/CodewindManager.ts
+++ b/dev/src/codewind/connection/CodewindManager.ts
@@ -74,7 +74,7 @@ export default class CodewindManager implements vscode.Disposable {
 
         // all validation that this connection is good must be done by this point
 
-        const newConnection: Connection = new Connection(uri, mcVersion, socketNS, workspace);
+        const newConnection: Connection = new Connection(uri, mcVersion, socketNS, workspace, true);
         Log.i("New Connection @ " + uri);
         this._connections.push(newConnection);
         // ConnectionManager.saveConnections();

--- a/dev/src/codewind/connection/CodewindManager.ts
+++ b/dev/src/codewind/connection/CodewindManager.ts
@@ -74,7 +74,7 @@ export default class CodewindManager implements vscode.Disposable {
 
         // all validation that this connection is good must be done by this point
 
-        const newConnection: Connection = new Connection(uri, mcVersion, socketNS, workspace, true);
+        const newConnection: Connection = new Connection(uri, mcVersion, socketNS, workspace, false);
         Log.i("New Connection @ " + uri);
         this._connections.push(newConnection);
         // ConnectionManager.saveConnections();

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -48,7 +48,8 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         public readonly url: vscode.Uri,
         public readonly version: number,
         public readonly socketNS: string,
-        workspacePath_: string
+        workspacePath_: string,
+        public readonly remote: boolean
     ) {
         this.socket = new MCSocket(this, socketNS);
         this.workspacePath = vscode.Uri.file(workspacePath_);
@@ -57,7 +58,12 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
 
         // caller must await on this promise before expecting this connection to function correctly
         // it does happen very quickly (< 1s) but be aware of potential race here
-        this.initFileWatcherPromise = this.initFileWatcher();
+        if (!remote) {
+            this.initFileWatcherPromise = this.initFileWatcher();
+        } else {
+            // Disable file-watcher in remote mode for now.
+            this.initFileWatcherPromise = new Promise<void>((resolve) => (resolve()));
+        }
 
         Log.i(`Created new Connection @ ${this}, workspace ${this.workspacePath}`);
     }

--- a/dev/src/command/connection/BindProjectCmd.ts
+++ b/dev/src/command/connection/BindProjectCmd.ts
@@ -36,11 +36,13 @@ export default async function bindProject(connection: Connection): Promise<void>
             vscode.window.showErrorMessage(`You must select a project under the workspace; not the entire workspace.`);
             return;
         }
-        else if (!dirToBindUri.fsPath.startsWith(connection.workspacePath.fsPath)) {
-            Log.d(`${dirToBindUri.fsPath} is not under workspace ${connection.workspacePath.fsPath}`);
-            vscode.window.showErrorMessage(
-                `Currently, projects to be imported must be located under the workspace at ${connection.workspacePath.fsPath}`);
-            return;
+        if (!connection.remote) {
+            if (!dirToBindUri.fsPath.startsWith(connection.workspacePath.fsPath)) {
+                Log.d(`${dirToBindUri.fsPath} is not under workspace ${connection.workspacePath.fsPath}`);
+                vscode.window.showErrorMessage(
+                    `Currently, projects to be imported must be located under the workspace at ${connection.workspacePath.fsPath}`);
+                return;
+            }
         }
         const response = await UserProjectCreator.validateAndBind(connection, dirToBindUri);
         if (response == null) {

--- a/dev/src/constants/Endpoints.ts
+++ b/dev/src/constants/Endpoints.ts
@@ -28,6 +28,7 @@ export enum MCEndpoints {
     CREATE_FROM_TEMPLATE = "api/v1/projects/",
     PREBIND_VALIDATE = "api/v1/validate",
     BIND = "api/v1/projects/bind",
+    REMOTE_BIND_START = "api/v1/projects/remote-bind/start",
     REGISTRY = "api/v1/registry",
 }
 
@@ -43,6 +44,9 @@ export enum ProjectEndpoints {
     OPEN = "open",
     CLOSE = "close",
     UNBIND = "unbind",
+
+    UPLOAD = "remote-bind/upload",
+    REMOTE_BIND_END = "remote-bind/end",
 
     CAPABILITIES = "capabilities",
 }


### PR DESCRIPTION
This PR adds (very basic) remote mode support.

To enable:
- Edit `CodewindManager.ts` and change the remote flag on the `new Connection(` object from `false` to `true`
- Start Codewind pfe from the root of a git checkout with `./start.sh --remote` instead of `./run.sh`. (You can build the images manually with `script/build.sh`.)
- Start VSCode with the plugin enabled *after* you have started pfe with `./start.sh --remote` so it doesn't use the installer to pull images.