### PR TITLE
Reset to HEAD after running packaging script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,8 @@ spec:
         stage("Build for Theia") {
             steps {
                 container("vscode-builder") {
+                    // Reset changes from the vs code package.sh
+                    sh 'git reset --hard HEAD'
                     sh 'ci-scripts/package.sh theia'
                     stash includes: '*.vsix', name: 'deployables'
                 }


### PR DESCRIPTION
Commands deleted from VS Code were also deleted from Theia
Fixes https://github.com/eclipse/codewind/issues/241

Signed-off-by: Tim Etchells <timetchells@ibm.com>