### PR TITLE
Enable remote bind on project creation.

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -48,16 +48,6 @@
             "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
             "dev": true
         },
-<<<<<<< HEAD
-        "@types/form-data": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-            "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/fs-extra": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
@@ -66,8 +56,6 @@
                 "@types/node": "*"
             }
         },
-=======
->>>>>>> 910b8b19c018c9fca8ce05631315d07b817756da
         "@types/glob": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -115,16 +103,9 @@
             "dev": true
         },
         "@types/node": {
-<<<<<<< HEAD
-            "version": "10.14.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
-            "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
-=======
             "version": "10.14.15",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.15.tgz",
-            "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==",
-            "dev": true
->>>>>>> 910b8b19c018c9fca8ce05631315d07b817756da
+            "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g=="
         },
         "@types/request": {
             "version": "2.48.2",
@@ -675,6 +656,17 @@
                 "mime-types": "^2.1.12"
             }
         },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -720,6 +712,12 @@
             "requires": {
                 "is-glob": "^4.0.1"
             }
+        },
+        "graceful-fs": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+            "dev": true
         },
         "growl": {
             "version": "1.10.5",
@@ -911,6 +909,15 @@
             "integrity": "sha512-0EdQvHuLm7yJ7lyG5dp7Q3X2ku++BG5ZHaJ5FTnaXpKqDrw4pMxel5Bt3oAYMthnrthFBdnZ1FcsXTPyrQlV0w==",
             "requires": {
                 "minimist": "^1.2.0"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsprim": {
@@ -1409,6 +1416,12 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
             "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
         },
         "uri-js": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -496,6 +496,7 @@
         "@types/socketio-wildcard": "^2.0.1",
         "@types/stack-trace": "0.0.29",
         "chai": "^4.2.0",
+        "fs-extra": "^8.0.0",
         "socketio-wildcard": "^2.0.0",
         "ts-node": "^7.0.1",
         "tslint": "^5.16.0",

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -46,6 +46,8 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     private _projects: Project[] = [];
     private needProjectUpdate: boolean = true;
 
+    public readonly remote: boolean;
+
     constructor(
         public readonly url: vscode.Uri,
         cwEnv: ICWEnvData,
@@ -55,10 +57,11 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         this.versionStr = CWEnvironment.getVersionAsString(cwEnv.version);
         this.tektonStatus = cwEnv.tektonStatus;
         this.host = this.getHost(url);
+        this.remote = cwEnv.remote;
 
         // caller must await on this promise before expecting this connection to function correctly
         // it does happen very quickly (< 1s) but be aware of potential race here
-        if (!cwEnv.remote) {
+        if (!this.remote) {
             this.initFileWatcherPromise = this.initFileWatcher();
         } else {
             // Disable file-watcher in remote mode for now.

--- a/dev/src/codewind/connection/InstallerWrapper.ts
+++ b/dev/src/codewind/connection/InstallerWrapper.ts
@@ -283,7 +283,7 @@ namespace InstallerWrapper {
         let hadOldVersionRunning = false;
         Log.i(`Ready to install and start Codewind ${tag}`);
         if (status.started.length > 0) {
-            if (!status.started.includes(tag)) {
+            if (status.started.includes(tag)) {
                 Log.i("The correct version of Codewind is already started");
                 return;
             }

--- a/dev/src/codewind/connection/UserProjectCreator.ts
+++ b/dev/src/codewind/connection/UserProjectCreator.ts
@@ -11,7 +11,6 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
-import { inspect } from "util";
 import * as fs from "fs-extra";
 import * as zlib from "zlib";
 
@@ -68,12 +67,12 @@ namespace UserProjectCreator {
             throw new Error(failedResult.error);
         }
 
-        // const result = creationRes.result as IProjectInitializeInfo;
+        const projectTypeInfo = creationRes.result as IProjectTypeInfo;
         // const targetDir = vscode.Uri.file(creationRes.projectPath);
         const targetDir = creationRes.projectPath;
 
         // create succeeded, now we bind
-        await requestBind(connection, projectName, targetDir, template.language, template.projectType);
+        await bind(connection, projectName, targetDir, projectTypeInfo);
         return { projectName, projectPath: creationRes.projectPath };
     }
 
@@ -123,6 +122,12 @@ namespace UserProjectCreator {
             projectTypeInfo = userProjectType;
         }
 
+        return bind(connection, projectName, pathToBind, projectTypeInfo);
+    }
+
+    async function bind(connection: Connection, projectName: string,
+                        pathToBind: string, projectTypeInfo: IProjectTypeInfo):
+                        Promise<INewProjectInfo | undefined> {
         if (connection.remote) {
             return bindRemote(connection, projectName, pathToBind, projectTypeInfo);
         } else {
@@ -134,7 +139,7 @@ namespace UserProjectCreator {
                              pathToBind: string, projectTypeInfo: IProjectTypeInfo):
                              Promise<INewProjectInfo | undefined> {
 
-        await requestBind(connection, projectName, pathToBind, projectTypeInfo.language, projectTypeInfo.projectType);
+        await requestLocalBind(connection, projectName, pathToBind, projectTypeInfo.language, projectTypeInfo.projectType);
         return { projectName, projectPath: pathToBind };
     }
 
@@ -276,7 +281,7 @@ namespace UserProjectCreator {
         return selectedDirs[0];
     }
 
-    async function requestBind(connection: Connection, projectName: string, dirToBindContainerPath: string, language: string, projectType: string)
+    async function requestLocalBind(connection: Connection, projectName: string, dirToBindContainerPath: string, language: string, projectType: string)
         : Promise<void> {
 
         const bindReq = {


### PR DESCRIPTION
This PR enables the plugin to use the remote-bind API when creating new or binding existing projects to codewind.
It uploads the source code to the remote pfe container so it can be built and run.