### PR TITLE
Enable copy on build

### DIFF
--- a/codewind.code-workspace
+++ b/codewind.code-workspace
@@ -5,9 +5,6 @@
 		},
 		{
 			"path": "."
-		},
-		{
-			"path": "/Users/tobes/workspaces/git/eclipse/codewind"
 		}
 	],
 	"settings": {

--- a/dev/src/command/project/RequestBuildCmd.ts
+++ b/dev/src/command/project/RequestBuildCmd.ts
@@ -31,20 +31,6 @@ export default async function requestBuildCmd(project: Project): Promise<void> {
         // still do the build, though.
     }*/
 
-    // if (project.connection.remote) {
-    //     Log.i(`Copying updated files from ${project.localPath} to ${project.connection.host}`);
-    //     await syncChangedFiles(project);
-    // } else {
-    //     Log.i(`Local build from local file system at ${project.localPath}`);
-    // }
-
     Log.i(`Request build for project ${project.name}`);
     Requester.requestBuild(project);
 }
-
-// async function syncChangedFiles(project: Project) : Promise<void> {
-//     Log.i(`Request build for project ${project.name} ${project.localPath.fsPath}`);
-//     await exec(`docker exec -it codewind-pfe sh -c "rm -rf /codewind-workspace/${project.name}/*"`);
-//     await exec(`docker cp ${project.localPath.fsPath}/ codewind-pfe:/codewind-workspace`);
-// }
-


### PR DESCRIPTION
This PR adds basic sync (upload only, no deletion) when build button is clicked.
I've moved and refactored the upload code so it is available for builds as well as the initial bind process.
The next step is to add an API to PFE we can call to remove the old code and so that file deletes/renames aren't ignored.