### PR TITLE
Add dark mode application monitor as default

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -555,7 +555,7 @@ export default class Project implements vscode.QuickPickItem {
         if (!monitorPageUrlStr.endsWith("/")) {
             monitorPageUrlStr += "/";
         }
-        return monitorPageUrlStr + appMetricsPath + "/";
+        return monitorPageUrlStr + appMetricsPath + "/?theme=dark";
     }
 
     ///// Setters


### PR DESCRIPTION
On click of `application monitor` on a project, goes to the dark-mode monitor to match the performance dashboard. 

If the darkmode doesn't exist (i.e the version the metrics dashboard is not recent enough), this will just go to the standard light-mode.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>