### PR TITLE
Only add upstream trigger for current branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ spec:
     }
 
     triggers {
-        upstream(upstreamProjects: "Codewind/codewind-installer/master", threshold: hudson.model.Result.SUCCESS)
+        upstream(upstreamProjects: "Codewind/codewind-installer/${env.GIT_BRANCH}", threshold: hudson.model.Result.SUCCESS)
     }
 
     parameters {
@@ -172,7 +172,6 @@ spec:
                 skipDefaultCheckout()
             }
 
-            agent any
             steps {
                 mail to: 'jspitman@ca.ibm.com, timetchells@ibm.com',
                 subject: "${currentBuild.currentResult}: Upstream triggered build for ${currentBuild.fullProjectName}",

--- a/dev/bin/cli-pull.sh
+++ b/dev/bin/cli-pull.sh
@@ -32,14 +32,14 @@ extract_property () {
 # Test the linux cli's sha vs the build_info linux cli's sha
 # Return 1 for no upgrade, 0 for upgrade available
 is_cli_upgrade_available () {
-    local cli_props_file="cli.properties";
+    local cli_props_file="cli_version.properties";
     local cli_props_url="$download_dir_url/build_info.properties"
     download $cli_props_url $cli_props_file
     cli_lastbuild=$(extract_property $cli_props_file build_info.url)
     echo "Latest cli $cli_branch build is $cli_lastbuild"
 
     latest_sha=$(extract_property $cli_props_file build_info.linux.SHA-1)
-    rm $cli_props_file
+    #rm $cli_props_file
 
     local test_file="linux/$cli_basename"
     if [[ ! -f $test_file ]]; then
@@ -93,7 +93,5 @@ for platform in ${platforms[*]}; do
     mkdir -p $platform
     get_cli $platform
 done
-
-echo "$cli_lastbuild" > cli_build.txt;
 
 echo "Successfully pulled Codewind CLI"


### PR DESCRIPTION
IE vscode master should only be triggered by installer master, 0.4.0 by 0.4.0, etc

Signed-off-by: Tim Etchells <timetchells@ibm.com>


One drawback is that if an open PR on installer happens to have the same number as an open PR on VS Code, it will trigger. But I think that is not a big deal.