### PR TITLE
Rename binary to cwctl

### DIFF
--- a/dev/bin/cli-pull.sh
+++ b/dev/bin/cli-pull.sh
@@ -11,7 +11,7 @@ fi
 
 echo "Downloading latest Codewind CLI built from $cli_branch"
 
-cli_basename="codewind-installer"
+cli_basename="cwctl"
 
 download () {
     local url=$1

--- a/dev/src/codewind/connection/InstallerWrapper.ts
+++ b/dev/src/codewind/connection/InstallerWrapper.ts
@@ -32,8 +32,8 @@ import { IInitializationResponse } from "./UserProjectCreator";
 const STRING_NS = StringNamespaces.STARTUP;
 
 const BIN_DIR = "bin";
-const INSTALLER_EXECUTABLE = "codewind-installer";
-const INSTALLER_EXECUTABLE_WIN = "codewind-installer.exe";
+const INSTALLER_EXECUTABLE = "cwctl";
+const INSTALLER_EXECUTABLE_WIN = "cwctl.exe";
 const INSTALLER_PREREQS: { [s: string]: string[]; } = {
     [INSTALLER_EXECUTABLE]: ["appsody"],
     [INSTALLER_EXECUTABLE_WIN]: ["appsody.exe"]


### PR DESCRIPTION
**Problem**
CLI binary name has been changed from `codewind-installer` -> `cwctl`. The plugin is pulling the old named binary.

**Solution**
Rename the binary in the plugin code

Signed-off-by: Liam Hampton liam.hampton@ibm.com