### PR TITLE
Ping ready endpoint immediately, not after 1s

### DIFF
--- a/dev/src/codewind/connection/CodewindManager.ts
+++ b/dev/src/codewind/connection/CodewindManager.ts
@@ -171,7 +171,7 @@ export default class CodewindManager implements vscode.Disposable {
         const waitingForReadyProm = Requester.waitForReady(baseUrl);
         vscode.window.setStatusBarMessage(`${Resources.getOcticon(Resources.Octicons.sync, true)}` +
             `Waiting for Codewind to start...`, waitingForReadyProm);
-        return waitingForReadyProm;
+        return waitingForReadyProm.then(Promise.resolve);
     }
 
     public async connect(uri: vscode.Uri, cwEnv: CWEnvData): Promise<Connection> {


### PR DESCRIPTION
This makes the Connection UI update a lot smoother initially, since it no longer shows Disconnected briefly.

Signed-off-by: Tim Etchells <timetchells@ibm.com>