### PR TITLE
Recreate local connection on refresh if URL change, plus add some error logging

### DIFF
--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -253,7 +253,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
                 continue;
             }
 
-            let project: Project;
+            let project: Project | undefined;
 
             // If we already have a Project object for this project, just update it, don't make a new object
             const existing = oldProjects.find( (p) => p.id === projectInfo.projectID);
@@ -264,11 +264,19 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
                 // Log.d("Reuse project " + project.name);
             }
             else {
-                project = new Project(projectInfo, this);
-                initPromises.push(project.initPromise);
-                Log.d("New project " + project.name);
+                try {
+                    project = new Project(projectInfo, this);
+                    initPromises.push(project.initPromise);
+                    Log.d("New project " + project.name);
+                }
+                catch (err) {
+                    Log.e(`Error creating new project with ID ${projectInfo.id} name ${projectInfo.name}`, err);
+                    vscode.window.showErrorMessage(`Error with new project ${projectInfo.name}: ${MCUtil.errToString(err)}`);
+                }
             }
-            this._projects.push(project);
+            if (project) {
+                this._projects.push(project);
+            }
         }
 
         // Log.d("Awaiting init promises " + Date.now());

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -111,6 +111,17 @@ export default class LocalCodewindManager {
         this._localConnection = undefined;
     }
 
+    public async refresh(): Promise<boolean> {
+        const cwUrl = await CLILifecycleWrapper.getCodewindUrl();
+        if (this.localConnection && cwUrl && cwUrl !== this.localConnection.url) {
+            // If the URL has changed, dispose of the old connection, and connect to the new PFE.
+            await ConnectionManager.instance.removeConnection(this.localConnection);
+            await this.startCodewind();
+            return true;
+        }
+        return false;
+    }
+
     public changeState(newState: CodewindStates): void {
         Log.d(`Codewind state changing from ${this._state} to ${newState}`);
         this._state = newState;

--- a/dev/src/command/connection/RefreshConnectionCmd.ts
+++ b/dev/src/command/connection/RefreshConnectionCmd.ts
@@ -14,8 +14,18 @@ import * as vscode from "vscode";
 import Connection from "../../codewind/connection/Connection";
 import Translator from "../../constants/strings/translator";
 import StringNamespaces from "../../constants/strings/StringNamespaces";
+import LocalCodewindManager from "../../codewind/connection/local/LocalCodewindManager";
 
 export default async function refreshConnectionCmd(connection: Connection): Promise<void> {
+
+    if (!connection.isRemote) {
+       const localHasChanged = await LocalCodewindManager.instance.refresh();
+       if (localHasChanged) {
+           vscode.window.showInformationMessage(`Reconnected to Local Codewind`);
+           return;
+       }
+    }
+
     vscode.window.showInformationMessage(Translator.t(StringNamespaces.CMD_MISC, "refreshedConnection"));
     return connection.forceUpdateProjectList(true);
 }


### PR DESCRIPTION
You can now restart Codewind outside of VS Code, and then refresh to pick it up

Signed-off-by: Tim Etchells <timetchells@ibm.com>