### PR TITLE
refresh package-lock to use latest fw demon

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -31,9 +31,9 @@
             "dev": true
         },
         "@types/chai": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
-            "integrity": "sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.4.tgz",
+            "integrity": "sha512-7qvf9F9tMTzo0akeswHPGqgUx/gIaJqrOEET/FCD8CFRkSUHlygQiM5yB6OvjrtdxBVLSyw7COJubsFYs0683g==",
             "dev": true
         },
         "@types/circular-json": {
@@ -104,9 +104,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.14.22",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-            "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
+            "version": "10.17.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
+            "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA==",
             "dev": true
         },
         "@types/request": {
@@ -144,9 +144,9 @@
             }
         },
         "@types/rimraf": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-            "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.3.tgz",
+            "integrity": "sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==",
             "dev": true,
             "requires": {
                 "@types/glob": "*",
@@ -409,9 +409,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
-            "integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.3.tgz",
+            "integrity": "sha512-GtrxGuRf6bzHQmXWRepvsGnXpkQkVU+D2/9a7dAe4a7v1NhrfZOZ2oKf76M3nOs46fFYL8D+Q8JYA4GYeJ8Cjw==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -429,8 +429,8 @@
             "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
         },
         "codewind-filewatcher": {
-            "version": "https://download.eclipse.org/codewind/codewind-filewatcher-ts/master//latest/filewatcherd-node_latest.tar.gz",
-            "integrity": "sha512-LEx6MNEZKN8VaFkHdQ9cUDMHa3Fhx3Mur/uS9yG9gNEPv6tII0uH+ROaKI6VuSjs1RVOBsx8557UOFdZypTQYA==",
+            "version": "https://download.eclipse.org/codewind/codewind-filewatcher-ts/master/latest/filewatcherd-node_latest.tar.gz",
+            "integrity": "sha512-R7y8dHgQpl9knRXg9FGp4aoxQELSEyk58boIpcCDNsutfmXKYZtC5RBm1K7Ym1pNZVvyBgRCIN9WVOYfyaWMYQ==",
             "requires": {
                 "chokidar": "^3.0.2",
                 "request": "^2.88.0",
@@ -709,9 +709,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "growl": {
             "version": "1.10.5",
@@ -796,9 +796,9 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
-            "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
             "dev": true,
             "requires": {
                 "agent-base": "^4.3.0",
@@ -1138,9 +1138,9 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-            "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz",
+            "integrity": "sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw=="
         },
         "psl": {
             "version": "1.4.0",
@@ -1314,9 +1314,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.13",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+            "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

The latest filewatcher demon was not being pulled in by vscode due to the package-lock not having changed