### PR TITLE
Hide container shell command for remote projects

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -455,53 +455,53 @@
                 },
                 {
                     "command": "%cmdID_containerShell%",
-                    "when": "%isEnabledProject%",
+                    "when": "%isShellableProject%",
                     "group": "ext.cw.a@2"
                 },
                 {
                     "command": "%cmdID_openAppMonitor%",
                     "when": "%isProjectWithMetrics%",
-                    "group": "ext.cw.a@3"
+                    "group": "ext.cw.b@3"
                 },
                 {
                     "command": "%cmdID_openPerfDashboard%",
                     "when": "%isProjectWithMetrics%",
-                    "group": "ext.cw.a@4"
+                    "group": "ext.cw.b@4"
                 },
                 {
                     "command": "%cmdID_addProjToWorkspace%",
                     "when": "%isProject%",
-                    "group": "ext.cw.b@0"
+                    "group": "ext.cw.c@0"
                 },
                 {
                     "command": "%cmdID_showAllLogs%",
                     "when": "%isEnabledProject%",
-                    "group": "ext.cw.c@1"
+                    "group": "ext.cw.d@1"
                 },
                 {
                     "command": "%cmdID_hideAllLogs%",
                     "when": "%isEnabledProject%",
-                    "group": "ext.cw.c@2"
+                    "group": "ext.cw.d@2"
                 },
                 {
                     "command": "%cmdID_manageLogs%",
                     "when": "%isEnabledProject%",
-                    "group": "ext.cw.c@3"
+                    "group": "ext.cw.d@3"
                 },
                 {
                     "command": "%cmdID_restartRun%",
                     "when": "%isRestartableProject%",
-                    "group": "ext.cw.d@0"
+                    "group": "ext.cw.e@0"
                 },
                 {
                     "command": "%cmdID_restartDebug%",
                     "when": "%isRestartableProject%",
-                    "group": "ext.cw.d@1"
+                    "group": "ext.cw.e@1"
                 },
                 {
                     "command": "%cmdID_attachDebugger%",
                     "when": "%isDebuggableProject%",
-                    "group": "ext.cw.d@2"
+                    "group": "ext.cw.e@2"
                 },
                 {
                     "command": "%cmdID_attachDebugger%",
@@ -511,7 +511,7 @@
                 {
                     "command": "%cmdID_requestBuild%",
                     "when": "%isEnabledProject%",
-                    "group": "ext.cw.e@0"
+                    "group": "ext.cw.f@0"
                 },
                 {
                     "command": "%cmdID_requestBuild%",
@@ -521,12 +521,12 @@
                 {
                     "command": "%cmdID_enableAutoBuild%",
                     "when": "%isEnabledAutoBuildOff%",
-                    "group": "ext.cw.e@2"
+                    "group": "ext.cw.f@2"
                 },
                 {
                     "command": "%cmdID_disableAutoBuild%",
                     "when": "%isEnabledAutoBuildOn%",
-                    "group": "ext.cw.e@2"
+                    "group": "ext.cw.f@2"
                 },
                 {
                     "command": "%cmdID_disable%",

--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -146,6 +146,7 @@
     "isDebuggableProject":      "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.debuggable.*/",
     "isProjectWithMetrics":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.metricsAvailable.*/",
     "isRestartableProject":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.restartable.*/",
+    "isShellableProject":       "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.shellable.*/",
     "isEnabledAutoBuildOn":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOn/",
     "isEnabledAutoBuildOff":    "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOff/"
 }

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -582,6 +582,10 @@ export default class Project implements vscode.QuickPickItem {
         return this._lastSync;
     }
 
+    public get canContainerShell(): boolean {
+        return !this.connection.isRemote; // && !!this.containerID;
+    }
+
     ///// Setters
 
     /**

--- a/dev/src/command/project/ContainerShellCmd.ts
+++ b/dev/src/command/project/ContainerShellCmd.ts
@@ -16,7 +16,8 @@ import Translator from "../../constants/strings/translator";
 import StringNamespaces from "../../constants/strings/StringNamespaces";
 
 export default async function containerShellCmd(project: Project): Promise<void> {
-    if (project.containerID == null || project.containerID === "") {
+    const containerID = project.containerID;
+    if (!containerID) {
         vscode.window.showWarningMessage(Translator.t(StringNamespaces.CMD_MISC, "noContainerForShell", { projectName: project.name }));
         return;
     }
@@ -35,7 +36,7 @@ export default async function containerShellCmd(project: Project): Promise<void>
     };
 
     const term: vscode.Terminal = vscode.window.createTerminal(options);
-    term.sendText(`docker exec -it ${project.containerID} /usr/bin/env ${toExec}`);     // non-nls
+    term.sendText(`docker exec -it ${containerID} /usr/bin/env ${toExec}`);     // non-nls
     term.show();
 }
 

--- a/dev/src/view/TreeItemContext.ts
+++ b/dev/src/view/TreeItemContext.ts
@@ -54,6 +54,8 @@ enum TreeItemContextValues {
 
     PROJ_RESTARTABLE = "restartable",
     PROJ_METRICS = "metricsAvailable",
+
+    PROJ_SHELLABLE = "shellable",
 }
 
 namespace TreeItemContext {
@@ -122,6 +124,10 @@ namespace TreeItemContext {
 
         if (project.capabilities.metricsAvailable) {
             contextValues.push(TreeItemContextValues.PROJ_METRICS);
+        }
+
+        if (project.canContainerShell) {
+            contextValues.push(TreeItemContextValues.PROJ_SHELLABLE);
         }
 
         // The final result will look like eg: "ext.cw.project.enabled.autoBuildOn"


### PR DESCRIPTION
Also move app monitor / perf dashboard actions into their own menu section

Signed-off-by: Tim Etchells <timetchells@ibm.com>