### PR TITLE
Add CLI upgrade command and show all CLI output

### DIFF
--- a/dev/src/MCUtil.ts
+++ b/dev/src/MCUtil.ts
@@ -10,24 +10,15 @@
  *******************************************************************************/
 
 import * as vscode from "vscode";
-import * as path from "path";
 import { promisify } from "util";
 import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 import Log from "./Logger";
 import Constants from "./constants/Constants";
 
 namespace MCUtil {
-
-    /**
-     * Returns the last segment of the given path, with no starting slash.
-     * Trailing slash is kept if present.
-     *
-     * lastPathSegment("/home/tim/test/dir/") -> "dir/"
-     */
-    export function lastPathSegment(p: string): string {
-        return p.substr(p.lastIndexOf(path.sep) + 1);
-    }
 
     export function uppercaseFirstChar(input: string): string {
         return input.charAt(0).toUpperCase() + input.slice(1);
@@ -194,6 +185,13 @@ namespace MCUtil {
     async function isCwWorkspaceOrProject(dirPath: string): Promise<boolean> {
         return (await promisify(fs.readdir)(dirPath))
             .some((file) => CW_FILES.includes(file.toString()));
+    }
+
+    export function getCWWorkspacePath(): string {
+        if (MCUtil.getOS() === "windows") {
+            return "C:\\codewind-workspace";
+        }
+        return path.join(os.homedir(), "codewind-workspace");
     }
 }
 

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -62,7 +62,7 @@ export default class LocalCodewindManager {
         }
         catch (err) {
             if (!CLIWrapper.isCancellation(err)) {
-                vscode.window.showErrorMessage(MCUtil.errToString(err));
+                CLIWrapper.showCLIError(MCUtil.errToString(err));
             }
             return;
         }

--- a/dev/src/command/StartCodewindCmd.ts
+++ b/dev/src/command/StartCodewindCmd.ts
@@ -15,6 +15,7 @@ import Log from "../Logger";
 import LocalCodewindManager from "../codewind/connection/local/LocalCodewindManager";
 import CLILifecycleWrapper from "../codewind/connection/local/CLILifecycleWrapper";
 import MCUtil from "../MCUtil";
+import CLIWrapper from "../codewind/connection/CLIWrapper";
 
 /**
  *
@@ -54,6 +55,6 @@ export default async function connectLocalCodewindCmd(start: boolean = true): Pr
     }
     catch (err) {
         Log.e("StartCodewindCmd error", err);
-        vscode.window.showErrorMessage(`Error initializing Codewind: ${MCUtil.errToString(err)}`);
+        CLIWrapper.showCLIError(`Error initializing Codewind: ${MCUtil.errToString(err)}`);
     }
 }

--- a/dev/src/constants/Constants.ts
+++ b/dev/src/constants/Constants.ts
@@ -10,7 +10,6 @@
  *******************************************************************************/
 
 import { Uri } from "vscode";
-import * as path from "path";
 
 export namespace CWDocs {
     export function getDocLink(docPath: CWDocs): Uri {
@@ -30,8 +29,6 @@ export enum CWDocs {
  */
 namespace Constants {
     export const PROJ_SETTINGS_FILE_NAME = ".cw-settings";
-    export const CW_CONFIG_DIR = ".config";
-    export const CW_CONFIG_FILE = path.join(CW_CONFIG_DIR, "settings.json");
 
     export const CHE_WORKSPACEID_ENVVAR = "CHE_WORKSPACE_ID";
     export const CHE_API_EXTERNAL_ENVVAR = "CHE_API_EXTERNAL";

--- a/dev/src/constants/strings/strings-en.json
+++ b/dev/src/constants/strings/strings-en.json
@@ -71,7 +71,7 @@
         "moreInfoBtn": "More Info",
         "removeImagesBlockedStillRunning": "You cannot remove images if Codewind is still running. Stop Codewind, and try again.",
         "removeImagesModalWarning": "Are you sure you want to remove all Codewind Docker images? You will have to download them again before you can start Codewind again.",
-        "backendUpgradeRequired": "You cannot use the extension without installing version {{ tag }} of the Codewind backend."
+        "backendUpgradeRequired": "You cannot use Codewind without installing version {{ tag }} of the Codewind backend."
     },
 
     "logs": {


### PR DESCRIPTION
Run cwctl upgrade if upgrading to 0.6 or newer, and a workspace exists
https://github.com/eclipse/codewind/issues/846

Also add a "Codewind" output channel which shows all CLI commands being run, and their output

Signed-off-by: Tim Etchells <timetchells@ibm.com>