### PR TITLE
{hold for 0.7.0} Change links to app metrics dashboard

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -33,14 +33,6 @@ import { refreshProjectOverview } from "../../command/webview/ProjectOverviewPag
 import Constants from "../../constants/Constants";
 import Commands from "../../constants/Commands";
 
-/**
- * Used to determine App Monitor URL
- */
-const langToPathMap = new Map<string, string>();
-langToPathMap.set("java", "javametrics-dash");
-langToPathMap.set("nodejs", "appmetrics-dash");
-langToPathMap.set("swift", "swiftmetrics-dash");
-
 const STRING_NS = StringNamespaces.PROJECT;
 
 /**
@@ -565,17 +557,16 @@ export default class Project implements vscode.QuickPickItem {
     }
 
     public get appMonitorUrl(): string | undefined {
-        const appMetricsPath = langToPathMap.get(this.type.language);
-        const supported = appMetricsPath != null && this.capabilities.metricsAvailable;
+        const isSupportedLanguage = ['nodejs'].includes(this.type.language);
+        const supported = isSupportedLanguage && this.capabilities.metricsAvailable;
         Log.d(`${this.name} supports metrics ? ${supported}`);
         if (!supported || !this.appUrl) {
             return undefined;
         }
-        let monitorPageUrlStr = this.appUrl.toString();
-        if (!monitorPageUrlStr.endsWith("/")) {
-            monitorPageUrlStr += "/";
-        }
-        return monitorPageUrlStr + appMetricsPath + "/?theme=dark";
+        const pfeOrigin = this.detail;
+        const dashboardPath = `performance/codewind-metrics/dashboard/${this.type.language}`;
+        const appMonitorUrl = `${pfeOrigin}${dashboardPath}?theme=dark&projectID=${this.id}`;
+        return appMonitorUrl;
     }
 
     public get lastSync(): number {

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -564,7 +564,7 @@ export default class Project implements vscode.QuickPickItem {
             return undefined;
         }
         const pfeOrigin = this.detail;
-        const dashboardPath = `performance/codewind-metrics/dashboard/${this.type.language}`;
+        const dashboardPath = `performance/monitor/dashboard/${this.type.language}`;
         const appMonitorUrl = `${pfeOrigin}${dashboardPath}?theme=dark&projectID=${this.id}`;
         return appMonitorUrl;
     }

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -563,7 +563,7 @@ export default class Project implements vscode.QuickPickItem {
         if (!supported || !this.appUrl) {
             return undefined;
         }
-        const pfeOrigin = this.detail;
+        const pfeOrigin = this.connection.url.toString();
         const dashboardPath = `performance/monitor/dashboard/${this.type.language}`;
         const appMonitorUrl = `${pfeOrigin}${dashboardPath}?theme=dark&projectID=${this.id}`;
         return appMonitorUrl;


### PR DESCRIPTION
(Should not be merged before https://github.com/eclipse/codewind/pull/1015)

This is the VSCode component of https://github.com/eclipse/codewind/issues/977. There is a sister PR for the Eclipse plugin component https://github.com/eclipse/codewind-eclipse/pull/396

### Functionality:
Removes the existing links to the metrics dashboards hosted by the user's projects. For Node.js projects, this replaces the link with one pointing to the new Node metrics dashboard hosted by the performance container.

### Tests:
I haven't written automated tests for this as I did not see existing tests for this kind of functionality, and wasn't sure how you would like this tested. I'd be happy to do some though if you point me towards a test as a starting point :)