### PR TITLE
Improve 'developing' instructions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,29 @@
+## Developing Codewind for VS Code
+1. First, clone this repository and download our dependencies.
+```
+    git clone https://github.com/eclipse/codewind-vscode && \
+    cd codewind-vscode && \
+    cd dev/ && \
+    npm install && \
+    bin/pull.sh
+```
+2. Open [`codewind.code-workspace`](https://github.com/eclipse/codewind-vscode/blob/master/codewind.code-workspace), or just the `dev/` folder, in VS Code.
+3. Create a workspace (directory or `.code-workspace`) for Codewind extension use, and add the path to the `args` array in `dev/.vscode/launch.json`. An empty directory will work. VS Code will launch into this workspace.
+    - Do not modify the `--extensionDevelopmentPath`.
+4. Run the **Extension** launch in `launch.json` (hit F5). See [Developing Extensions](https://code.visualstudio.com/docs/extensions/developing-extensions) for more information.
+- To use a version of Codewind other than latest:
+    - `git checkout <release branch>`, eg `0.6.0`
+    - `export CW_CLI_BRANCH=0.6.0`
+    - If the release branch uses a different verison of Appsody,
+        - `export APPSODY_VERSION=<version>`, eg `0.4.10`
+    - `bin/pull.sh`
+    - Delete `CW_ENV: "dev"` from the `launch.json` `env`, so as to pull release images instead of `latest.` You can override the Codewind image tag to use by setting `CW_TAG: "0.6.0"` here.
+- You can build the extension `.vsix` yourself by running [`vsce package`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions) from `dev/`. Refer to the [`Jenkinsfile`](https://github.com/eclipse/codewind-vscode/blob/master/Jenkinsfile) to see the exact steps the build runs.
+- The extension bundles dependency executables. These are gitignored, but should be kept up-to-date on your local system with the same versions used in the `Jenkinsfile` `parameters` section. Run `dev/bin/pull.sh` to download the dependencies. Also see `dev/bin/README.txt`.
+- The [`prebuild`](https://github.com/eclipse/codewind-vscode/blob/master/dev/prebuild.js) script is used in the CI builds to build separate versions of the extension for VS Code and Theia, since each of those has some commands that the other does not. It deletes inapplicable commands from the `package.json`, and does not modify any ts/js code. Run this before `vsce package` to get a closer-to-production build, but be ready to revert the changes.
+
+## Building Codewind from the source
+1. Clone the [`codewind`](https://github.com/eclipse/codewind) repository.
+2. Clone the `codewind-vscode` repo.
+3. Run `codewind/script/build.sh` to run the Codewind build, or run `codewind/run.sh` to build and start Codewind.
+4. Run the extension by following the instructions in **Developing**.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,6 +18,7 @@
         - `export APPSODY_VERSION=<version>`, eg `0.4.10`
     - `bin/pull.sh`
     - Delete `CW_ENV: "dev"` from the `launch.json` `env`, so as to pull release images instead of `latest.` You can override the Codewind image tag to use by setting `CW_TAG: "0.6.0"` here.
+        - You can also `export CW_TAG=0.6.0` in the terminal, before launching VS Code from that same terminal. This works even outside of Extension Development mode.
 - You can build the extension `.vsix` yourself by running [`vsce package`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions) from `dev/`. Refer to the [`Jenkinsfile`](https://github.com/eclipse/codewind-vscode/blob/master/Jenkinsfile) to see the exact steps the build runs.
 - The extension bundles dependency executables. These are gitignored, but should be kept up-to-date on your local system with the same versions used in the `Jenkinsfile` `parameters` section. Run `dev/bin/pull.sh` to download the dependencies. Also see `dev/bin/README.txt`.
 - The [`prebuild`](https://github.com/eclipse/codewind-vscode/blob/master/dev/prebuild.js) script is used in the CI builds to build separate versions of the extension for VS Code and Theia, since each of those has some commands that the other does not. It deletes inapplicable commands from the `package.json`, and does not modify any ts/js code. Run this before `vsce package` to get a closer-to-production build, but be ready to revert the changes.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@
 ```
 2. Open [`codewind.code-workspace`](https://github.com/eclipse/codewind-vscode/blob/master/codewind.code-workspace), or just the `dev/` folder, in VS Code.
 3. Create a workspace (directory or `.code-workspace`) for Codewind extension use, and add the path to the `args` array in `dev/.vscode/launch.json`. An empty directory will work. VS Code will launch into this workspace.
-    - Do not modify the `--extensionDevelopmentPath`.
+    - When editing `launch.json`, do not modify the `--extensionDevelopmentPath`.
 4. Run the **Extension** launch in `launch.json` (hit F5). See [Developing Extensions](https://code.visualstudio.com/docs/extensions/developing-extensions) for more information.
 - To use a version of Codewind other than latest:
     - `git checkout <release branch>`, eg `0.6.0`

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,7 +8,7 @@
     bin/pull.sh
 ```
 2. Open [`codewind.code-workspace`](https://github.com/eclipse/codewind-vscode/blob/master/codewind.code-workspace), or just the `dev/` folder, in VS Code.
-3. Create a workspace (directory or `.code-workspace`) for Codewind extension use, and add the path to the `args` array in `dev/.vscode/launch.json`. An empty directory will work. VS Code will launch into this workspace.
+3. Create or identify a workspace (directory or `.code-workspace`, an empty directory will work) for Codewind extension use, and add the path to the `args` array in `dev/.vscode/launch.json`. VS Code will launch into this workspace.
     - When editing `launch.json`, do not modify the `--extensionDevelopmentPath`.
 4. Run the **Extension** launch in `launch.json` (hit F5). See [Developing Extensions](https://code.visualstudio.com/docs/extensions/developing-extensions) for more information.
 - To use a version of Codewind other than latest:

--- a/README.md
+++ b/README.md
@@ -40,18 +40,4 @@ Submit issues and contributions:
 - [Jenkins](https://ci.eclipse.org/codewind/job/Codewind/job/codewind-vscode/)
 
 ## Developing
-- To host the extension yourself so you can develop or debug it, clone this repository and run the **Extension** launch in `dev/.vscode/launch.json`. See [Developing Extensions](https://code.visualstudio.com/docs/extensions/developing-extensions) for more information.
-- If not run using the **Extension** launch, the tools will pull the latest Codewind release tag, eg. `0.3` (see [`DEFAULT_CW_TAG`](https://github.com/eclipse/codewind-vscode/blob/master/dev/src/codewind/connection/InstallerWrapper.ts)). To run against the latest development version of Codewind:
-    1. Start Codewind using [`run.sh`](https://github.com/eclipse/codewind/blob/master/run.sh) or [`start.sh`](https://github.com/eclipse/codewind/blob/master/start.sh).
-    2. From a terminal, run `export CW_TAG=latest` (or your Windows equivalent).
-    3. Close all instances of VS Code.
-    4. Launch VS Code (`code`) from the same shell so the environment is picked up.
-- You can also build the extension `.vsix` yourself by running [`vsce package`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions) from `dev/`. Refer to the [`Jenkinsfile`](https://github.com/eclipse/codewind-vscode/blob/master/Jenkinsfile) to see the exact steps the build runs.
-- The extension bundles dependency executables. These are gitignored, but should be kept up-to-date on your local system with the same versions used in the `Jenkinsfile` `parameters` section. Run `dev/bin/pull.sh` to download the dependencies. Also see `dev/bin/README.txt`.
-- The [`prebuild`](https://github.com/eclipse/codewind-vscode/blob/master/dev/prebuild.js) script is used in the CI builds to build separate versions of the extension for VS Code and Theia, since each of those has some commands that the other does not. It deletes inapplicable commands from the `package.json`, and does not modify any ts/js code. Run this before `vsce package` to get a closer-to-production build, but be ready to revert the changes.
-
-## Building Codewind from the source
-1. Clone the [`codewind`](https://github.com/eclipse/codewind) repository.
-2. Clone the `codewind-vscode` repo.
-3. Run `codewind/script/build.sh` to run the Codewind build, or run `codewind/run.sh` to build and start Codewind.
-4. Run the extension by following the instructions in **Developing**.
+See [DEVELOPING.md](https://github.com/eclipse/codewind-vscode/blob/master/DEVELOPING.md).


### PR DESCRIPTION
As more team members have started running the vs code extension in Extension Development mode, it has become clear that our developing documentation needs work. I've added some new detail, and improved the overall flow based on feedback from team members.

I also separated it into its own document, so that it doesn't pollute our marketplace README.