### PR TITLE
Improve Connection Settings and error handling

### DIFF
--- a/dev/res/css/connection-overview.css
+++ b/dev/res/css/connection-overview.css
@@ -2,7 +2,7 @@
 body {
     width: 90%;
     padding-top: 3%;
-    padding-left: 6%;
+    padding-left: 5%;
     padding-right: 5%;
 }
 

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -67,7 +67,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     }
 
     public get enabled(): boolean {
-        return this._socket != null;
+        return this.state !== ConnectionStates.DISABLED;
     }
 
     public get state(): ConnectionState {

--- a/dev/src/command/CommandUtil.ts
+++ b/dev/src/command/CommandUtil.ts
@@ -46,7 +46,7 @@ import { newRemoteConnectionCmd } from "./connection/NewConnectionCmd";
 import LocalCodewindManager from "../codewind/connection/local/LocalCodewindManager";
 import connectionOverviewCmd from "./connection/ConnectionOverviewCmd";
 import removeConnectionCmd from "./connection/RemoveConnectionCmd";
-import toggleConnectionEnablement from "./connection/ToggleConnectionEnablement";
+import toggleConnectionEnablementCmd from "./connection/ToggleConnectionEnablement";
 
 export function createCommands(): vscode.Disposable[] {
 
@@ -66,8 +66,8 @@ export function createCommands(): vscode.Disposable[] {
 
         vscode.commands.registerCommand(Commands.NEW_CONNECTION, newRemoteConnectionCmd),
         registerConnectionCommand(Commands.REMOVE_CONNECTION, removeConnectionCmd, undefined, false, true),
-        registerConnectionCommand(Commands.ENABLE_CONNECTION, toggleConnectionEnablement, true, false, true),
-        registerConnectionCommand(Commands.DISABLE_CONNECTION, toggleConnectionEnablement, false, false, true),
+        registerConnectionCommand(Commands.ENABLE_CONNECTION, toggleConnectionEnablementCmd, true, false, true),
+        registerConnectionCommand(Commands.DISABLE_CONNECTION, toggleConnectionEnablementCmd, false, false, true),
 
         registerConnectionCommand(Commands.CREATE_PROJECT, createProject, undefined, true, false),
         registerConnectionCommand(Commands.BIND_PROJECT, bindProject, undefined, true, false),

--- a/dev/src/command/connection/ToggleConnectionEnablement.ts
+++ b/dev/src/command/connection/ToggleConnectionEnablement.ts
@@ -16,9 +16,9 @@ import Connection from "../../codewind/connection/Connection";
 import Log from "../../Logger";
 import RemoteConnection from "../../codewind/connection/RemoteConnection";
 import MCUtil from "../../MCUtil";
-import remoteConnectionOverviewCmd from "./ConnectionOverviewCmd";
+import remoteConnectionSettingsCmd from "./ConnectionOverviewCmd";
 
-export default async function toggleConnectionEnablement(connection_: Connection, enable: boolean): Promise<void> {
+export default async function toggleConnectionEnablementCmd(connection_: Connection, enable: boolean): Promise<void> {
     if (!connection_.isRemote) {
         Log.e("Cannot toggle enablement for the local connection");
         return;
@@ -41,20 +41,20 @@ export default async function toggleConnectionEnablement(connection_: Connection
             }
             await connection.enable();
         }
-        vscode.window.showInformationMessage(`Successfully ${enable ? "connected to " : "disconnected from "} ${connection.url}`);
+        vscode.window.showInformationMessage(`Successfully ${enable ? "connected to" : "disconnected from"} ${connection.url}`);
     }
     catch (err) {
-        const errMsg = `Failed to ${enable ? "connect to " : "disconnect from "} ${connection.url}. ${MCUtil.errToString(err)}`;
+        const errMsg = `Failed to ${enable ? "connect to" : "disconnect from"} ${connection.label}: ${MCUtil.errToString(err)}`;
         Log.e(errMsg, err);
-        const openConnOverviewBtn = "Open Connection Overview";
+        const openConnSettingsBtn = "Open Connection Settings";
         const retryBtn = "Retry";
-        vscode.window.showErrorMessage(errMsg, openConnOverviewBtn, retryBtn)
+        vscode.window.showErrorMessage(errMsg, openConnSettingsBtn, retryBtn)
         .then((res) => {
-            if (res === openConnOverviewBtn) {
-                remoteConnectionOverviewCmd(connection);
+            if (res === openConnSettingsBtn) {
+                remoteConnectionSettingsCmd(connection);
             }
             else if (res === retryBtn) {
-                toggleConnectionEnablement(connection, enable);
+                toggleConnectionEnablementCmd(connection, enable);
             }
         });
     }

--- a/dev/src/command/webview/ConnectionOverview.ts
+++ b/dev/src/command/webview/ConnectionOverview.ts
@@ -26,7 +26,7 @@ import { URL } from "url";
 import Requester from "../../codewind/project/Requester";
 import removeConnectionCmd from "../connection/RemoveConnectionCmd";
 import { ConnectionState, ConnectionStates } from "../../codewind/connection/ConnectionState";
-import toggleConnectionEnablement from "../connection/ToggleConnectionEnablement";
+import toggleConnectionEnablementCmd from "../connection/ToggleConnectionEnablement";
 
 export enum ConnectionOverviewWVMessages {
     HELP = "help",
@@ -121,7 +121,7 @@ export default class ConnectionOverview {
         const html = getConnectionInfoPage(connectionInfo, state);
         if (process.env[Constants.CW_ENV_VAR] === Constants.CW_ENV_DEV) {
             const htmlWithFileProto = html.replace(/vscode-resource:\//g, "file:///");
-            fs.writeFile("/Users/laven.s@ibm.com/desktop/connectionOverview.html", htmlWithFileProto,
+            fs.writeFile(`${process.env.HOME}/connectionOverview.html`, htmlWithFileProto,
                 (err) => { if (err) { Log.e("Error writing out test connection overview", err); } }
             );
         }
@@ -177,7 +177,7 @@ export default class ConnectionOverview {
                 }
                 case ConnectionOverviewWVMessages.TOGGLE_CONNECTED: {
                     if (this.connection) {
-                        await toggleConnectionEnablement(this.connection, !this.connection.enabled);
+                        await toggleConnectionEnablementCmd(this.connection, !this.connection.enabled);
                     }
                     else {
                         Log.e("Received Toggle Connected event but there is no connection");
@@ -231,7 +231,6 @@ export default class ConnectionOverview {
 
         let ingressUrlStr = newConnectionInfo.ingressUrl.trim();
         try {
-            // tslint:disable-next-line: no-unused-expression
             if (!ingressUrlStr.includes("://")) {
                 Log.d(`No protocol; assuming https`);
                 ingressUrlStr = `https://${ingressUrlStr}`;
@@ -266,8 +265,6 @@ export default class ConnectionOverview {
             if (!canPing) {
                 throw new Error(`Failed to contact ${ingressUrl}. Make sure this URL is reachable.`);
             }
-
-            // Auth check? Version check?
         });
 
         const username = newConnectionInfo.username;

--- a/dev/src/command/webview/ConnectionOverviewPage.ts
+++ b/dev/src/command/webview/ConnectionOverviewPage.ts
@@ -111,7 +111,11 @@ export default function getConnectionInfoPage(connectionInfo: ConnectionOverview
                 connectionName = document.querySelector("#remote-connection-name").innerText;
             }
 
-            if (ingressInput === '${connectionInfo.ingressUrl}' && ingressUsername === '${connectionInfo.username}') {
+            // If none of the fields changed, treat it the same as a cancel
+            if (ingressInput === '${connectionInfo.ingressUrl}'
+                && ingressUsername === '${connectionInfo.username}'
+                && !ingressPassword) {
+
                 sendMsg("${ConnectionOverviewWVMessages.CANCEL}");
             } else {
                 // Data body is IConnectionInfoFields


### PR DESCRIPTION
- Fix bug where password failed to update if username was not changed
- Immediately refresh auth if credentials are changed
- Still save credentials even if they are wrong
- Allow opening Connection Settings if auth error on startup

Signed-off-by: Tim Etchells <timetchells@ibm.com>