### PR TITLE
Auto inject metrics toggle

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -304,6 +304,21 @@
                 "command": "%cmdID_removeProject%",
                 "title": "%cmdTitle_removeProject%",
                 "category": "%commandCategory%"
+            },
+            {
+                "command": "%cmdID_toggleAutoInjectMetrics%",
+                "title": "%cmdTitle_toggleAutoInjectMetrics%",
+                "category": "%commandCategory%"
+            },
+            {
+                "command": "%cmdID_enableAutoInjectMetrics%",
+                "title": "%cmdTitle_enableAutoInjectMetrics%",
+                "category": "%commandCategory%"
+            },
+            {
+                "command": "%cmdID_disableAutoInjectMetrics%",
+                "title": "%cmdTitle_disableAutoInjectMetrics%",
+                "category": "%commandCategory%"
             }
         ],
         "menus": {
@@ -547,6 +562,16 @@
                     "command": "%cmdID_removeProject%",
                     "when": "%isProject%",
                     "group": "ext.cw.z@1"
+                },
+                {
+                    "command": "%cmdID_enableAutoInjectMetrics%",
+                    "when": "%isEnabledAutoInjectMetricsOff%",
+                    "group": "ext.cw.f@2"
+                },
+                {
+                    "command": "%cmdID_disableAutoInjectMetrics%",
+                    "when": "%isEnabledAutoInjectMetricsOn%",
+                    "group": "ext.cw.f@2"
                 }
             ]
         }

--- a/dev/package.json
+++ b/dev/package.json
@@ -334,6 +334,14 @@
                 {
                     "command": "%cmdID_separator%",
                     "when": "never"
+                },
+                {
+                    "command": "%cmdID_enableAutoInjectMetrics%",
+                    "when": "never"
+                },
+                {
+                    "command": "%cmdID_disableAutoInjectMetrics%",
+                    "when": "never"
                 }
             ],
             "view/title": [
@@ -544,6 +552,16 @@
                     "group": "ext.cw.f@2"
                 },
                 {
+                    "command": "%cmdID_enableAutoInjectMetrics%",
+                    "when": "%isEnabledAutoInjectMetricsOff%",
+                    "group": "ext.cw.f@3"
+                },
+                {
+                    "command": "%cmdID_disableAutoInjectMetrics%",
+                    "when": "%isEnabledAutoInjectMetricsOn%",
+                    "group": "ext.cw.f@3"
+                },
+                {
                     "command": "%cmdID_disable%",
                     "when": "%isEnabledProject%",
                     "group": "ext.cw.z@0"
@@ -562,16 +580,6 @@
                     "command": "%cmdID_removeProject%",
                     "when": "%isProject%",
                     "group": "ext.cw.z@1"
-                },
-                {
-                    "command": "%cmdID_enableAutoInjectMetrics%",
-                    "when": "%isEnabledAutoInjectMetricsOff%",
-                    "group": "ext.cw.f@2"
-                },
-                {
-                    "command": "%cmdID_disableAutoInjectMetrics%",
-                    "when": "%isEnabledAutoInjectMetricsOn%",
-                    "group": "ext.cw.f@2"
                 }
             ]
         }

--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -122,6 +122,15 @@
     "cmdID_validate": "ext.cw.validate",
     "cmdTitle_validate": "Validate",
 
+    "cmdID_toggleAutoInjectMetrics": "ext.cw.toggleAutoInjectMetrics",
+    "cmdTitle_toggleAutoInjectMetrics": "Toggle Inject Metrics",
+
+    "cmdID_enableAutoInjectMetrics": "ext.cw.enableAutoInjectMetrics",
+    "cmdTitle_enableAutoInjectMetrics": "Enable Auto Inject Metrics",
+
+    "cmdID_disableAutoInjectMetrics": "ext.cw.disableAutoInjectMetrics",
+    "cmdTitle_disableAutoInjectMetrics": "Disable Auto Inject Metrics",
+
     "// None of items below are exposed to user": [
         "These regexes match Context IDs for Projects and Connections to determine command enablement",
         "See TreeItemFactory for how the Context IDs are set"
@@ -141,14 +150,16 @@
     "isConnectionWithRegistry": "viewItem =~ /ext\\.cw\\.connection.*\\.registry.*connected.*/",
     "isConnectionWithTekton": "viewItem =~ /ext\\.cw\\.connection.*\\.tekton.*connected.*/",
 
-    "isProject":                "viewItem =~ /ext\\.cw\\.project.*/",
-    "isEnabledProject":         "viewItem =~ /ext\\.cw\\.project\\.enabled.*/",
-    "isDisabledProject":        "viewItem =~ /ext\\.cw\\.project\\.disabled.*/",
-    "isStartedProject":         "viewItem =~ /ext\\.cw\\.project\\.enabled\\.started.*/",
-    "isDebuggableProject":      "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.debuggable.*/",
-    "isProjectWithMetrics":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.metricsAvailable.*/",
-    "isRestartableProject":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.restartable.*/",
-    "isShellableProject":       "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.shellable.*/",
-    "isEnabledAutoBuildOn":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOn/",
-    "isEnabledAutoBuildOff":    "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOff/"
+    "isProject":                        "viewItem =~ /ext\\.cw\\.project.*/",
+    "isEnabledProject":                 "viewItem =~ /ext\\.cw\\.project\\.enabled.*/",
+    "isDisabledProject":                "viewItem =~ /ext\\.cw\\.project\\.disabled.*/",
+    "isStartedProject":                 "viewItem =~ /ext\\.cw\\.project\\.enabled\\.started.*/",
+    "isDebuggableProject":              "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.debuggable.*/",
+    "isProjectWithMetrics":             "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.metricsAvailable.*/",
+    "isRestartableProject":             "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.restartable.*/",
+    "isShellableProject":               "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.shellable.*/",
+    "isEnabledAutoBuildOn":             "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOn/",
+    "isEnabledAutoBuildOff":            "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoBuildOff/",
+    "isEnabledAutoInjectMetricsOn":     "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoInjectMetricsOn/",
+    "isEnabledAutoInjectMetricsOff":    "viewItem =~ /ext\\.cw\\.project\\.enabled.*\\.autoInjectMetricsOff/"
 }

--- a/dev/res/css/project-overview.css
+++ b/dev/res/css/project-overview.css
@@ -17,7 +17,7 @@ body {
     margin-left: 1em;
 }
 
-#auto-build-toggle {
+#auto-build-toggle, #auto-inject-metrics-toggle {
     margin: 0;
     padding: 0;
     zoom: 1.25;

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -130,7 +130,7 @@ export default class Project implements vscode.QuickPickItem {
         // appImageLastBuild is a string
         this._lastImgBuild = new Date(Number(projectInfo.appImgLastBuild));
 
-        this._autoInjectMetricsEnabled = projectInfo.injectMetrics;
+        this._autoInjectMetricsEnabled = projectInfo.injectMetrics || false;
 
         this._ports = {
             appPort: undefined,

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -81,6 +81,7 @@ export default class Project implements vscode.QuickPickItem {
     // Dates below will always be set, but might be "invalid date"s
     private _lastBuild: Date;
     private _lastImgBuild: Date;
+    private _autoInjectMetricsEnabled: boolean;
 
     public static readonly diagnostics: vscode.DiagnosticCollection
         = vscode.languages.createDiagnosticCollection(Validator.DIAGNOSTIC_COLLECTION_NAME);
@@ -129,6 +130,8 @@ export default class Project implements vscode.QuickPickItem {
         // appImageLastBuild is a string
         this._lastImgBuild = new Date(Number(projectInfo.appImgLastBuild));
 
+        this._autoInjectMetricsEnabled = projectInfo.injectMetrics;
+
         this._ports = {
             appPort: undefined,
             debugPort: undefined,
@@ -169,6 +172,7 @@ export default class Project implements vscode.QuickPickItem {
         this.setLastBuild(projectInfo.lastbuild);
         this.setLastImgBuild(Number(projectInfo.appImageLastBuild));
         this.setAutoBuild(projectInfo.autoBuild);
+        this.setAutoInjectMetrics(projectInfo.injectMetrics);
 
         if (projectInfo.isHttps) {
             this._usesHttps = projectInfo.isHttps === true;
@@ -613,6 +617,10 @@ export default class Project implements vscode.QuickPickItem {
             vscode.workspace.workspaceFolders.some((folder) => this.localPath.fsPath.startsWith(folder.uri.fsPath));
     }
 
+    public get autoInjectMetricsEnabled(): boolean {
+        return this._autoInjectMetricsEnabled;
+    }
+
     ///// Setters
 
     /**
@@ -737,5 +745,22 @@ export default class Project implements vscode.QuickPickItem {
             // fall-back in case the user deleted the file, or something.
             vscode.window.showWarningMessage(`${settingsFilePath} does not exist or was not readable.`);
         }
+    }
+
+    public setAutoInjectMetrics(newInjectMetrics: boolean | undefined): boolean {
+        if (newInjectMetrics == null) {
+            return false;
+        }
+        const oldInjectMetrics = this._autoInjectMetricsEnabled;
+        this._autoInjectMetricsEnabled = newInjectMetrics;
+
+        const changed = this._autoInjectMetricsEnabled !== oldInjectMetrics;
+        if (changed) {
+            // onChange has to be invoked explicitly because this function can be called outside of update()
+            Log.d(`New autoInjectMetricsEnabled for ${this.name} is ${this._autoInjectMetricsEnabled}`);
+            this.onChange();
+        }
+
+        return changed;
     }
 }

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -251,8 +251,8 @@ namespace Requester {
         const newInjectMetrics: boolean = !project.autoInjectMetricsEnabled;
 
         // user-friendly action
-        const autoBuildMsgKey = newInjectMetrics ? "autoInjectMetricsEnable" : "autoInjectMetricsDisable";  // non-nls
-        const newAutoInjectMetricsUserStr: string = Translator.t(STRING_NS, autoBuildMsgKey);
+        const autoInjectMetricsMsgKey = newInjectMetrics ? "autoInjectMetricsEnable" : "autoInjectMetricsDisable";  // non-nls
+        const newAutoInjectMetricsUserStr: string = Translator.t(STRING_NS, autoInjectMetricsMsgKey);
 
         const body = {
             enable: newInjectMetrics

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -146,7 +146,7 @@ namespace Requester {
     }
 
     export async function requestToggleAutoBuild(project: Project): Promise<void> {
-        const newAutoBuild: boolean = !project.autoBuildEnabled;
+        const newAutoBuild: boolean = !project.autoInjectMetricsEnabled;
 
         // user-friendly action
         const autoBuildMsgKey = newAutoBuild ? "autoBuildEnable" : "autoBuildDisable";                  // non-nls
@@ -245,6 +245,22 @@ namespace Requester {
         const msg = Translator.t(STRING_NS, "checkingMetrics");
         const res = await doProjectRequest(project, ProjectEndpoints.METRICS_STATUS, {}, "GET", msg, true);
         return res.metricsAvailable;
+    }
+
+    export async function requestToggleAutoInjectMetrics(project: Project): Promise<void> {
+        const newInjectMetrics: boolean = !project.autoInjectMetricsEnabled;
+
+        // user-friendly action
+        const autoBuildMsgKey = newInjectMetrics ? "autoInjectMetricsEnable" : "autoInjectMetricsDisable";  // non-nls
+        const newAutoInjectMetricsUserStr: string = Translator.t(STRING_NS, autoBuildMsgKey);
+
+        const body = {
+            enable: newInjectMetrics
+        };
+
+        await doProjectRequest(project, ProjectEndpoints.METRICS_INJECTION, body, "POST", newAutoInjectMetricsUserStr);
+
+        project.setAutoInjectMetrics(newInjectMetrics);
     }
 
     /**

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -146,7 +146,7 @@ namespace Requester {
     }
 
     export async function requestToggleAutoBuild(project: Project): Promise<void> {
-        const newAutoBuild: boolean = !project.autoInjectMetricsEnabled;
+        const newAutoBuild: boolean = !project.autoBuildEnabled;
 
         // user-friendly action
         const autoBuildMsgKey = newAutoBuild ? "autoBuildEnable" : "autoBuildDisable";                  // non-nls

--- a/dev/src/command/CommandUtil.ts
+++ b/dev/src/command/CommandUtil.ts
@@ -47,6 +47,7 @@ import LocalCodewindManager from "../codewind/connection/local/LocalCodewindMana
 import connectionOverviewCmd from "./connection/ConnectionOverviewCmd";
 import removeConnectionCmd from "./connection/RemoveConnectionCmd";
 import toggleConnectionEnablementCmd from "./connection/ToggleConnectionEnablement";
+import toggleAutoInjectMetricsCmd from "./project/ToggleAutoInjectMetrics";
 
 export function createCommands(): vscode.Disposable[] {
 
@@ -105,6 +106,11 @@ export function createCommands(): vscode.Disposable[] {
 
         registerProjectCommand(Commands.OPEN_APP_MONITOR, openAppMonitorCmd, undefined, ProjectState.getStartedOrStartingStates()),
         registerProjectCommand(Commands.OPEN_PERF_DASHBOARD, openPerformanceDashboard, undefined, ProjectState.getStartedOrStartingStates()),
+
+        registerProjectCommand(Commands.TOGGLE_AUTOINJECTMETRICS, toggleAutoInjectMetricsCmd, undefined, ProjectState.getEnabledStates()),
+        // Enable and disable "Auto Inject Metrics" are the same as Toggle "Auto Inject Metrics" - they are just presented to the user differently.
+        registerProjectCommand(Commands.ENABLE_AUTOINJECTMETRICS, toggleAutoInjectMetricsCmd, undefined, ProjectState.getEnabledStates()),
+        registerProjectCommand(Commands.DISABLE_AUTOINJECTMETRICS, toggleAutoInjectMetricsCmd, undefined, ProjectState.getEnabledStates()),
     ];
 }
 

--- a/dev/src/command/project/ProjectOverviewCmd.ts
+++ b/dev/src/command/project/ProjectOverviewCmd.ts
@@ -17,6 +17,7 @@ import * as ProjectOverview from "../webview/ProjectOverviewPage";
 import Log from "../../Logger";
 import toggleAutoBuildCmd from "./ToggleAutoBuildCmd";
 import toggleEnablementCmd from "./ToggleEnablementCmd";
+import toggleAutoInjectMetricsCmd from "./ToggleAutoInjectMetrics";
 import requestBuildCmd from "./RequestBuildCmd";
 import Resources from "../../constants/Resources";
 import { removeProject } from "./RemoveProjectCmd";
@@ -83,6 +84,10 @@ function handleWebviewMessage(this: Project, msg: WebviewUtil.IWVMessage): void 
             }
             case ProjectOverview.ProjectOverviewWVMessages.EDIT: {
                 project.tryOpenSettingsFile();
+                break;
+            }
+            case ProjectOverview.ProjectOverviewWVMessages.TOGGLE_AUTOINJECTMETRICS: {
+                toggleAutoInjectMetricsCmd(project);
                 break;
             }
             default: {

--- a/dev/src/command/project/ToggleAutoInjectMetrics.ts
+++ b/dev/src/command/project/ToggleAutoInjectMetrics.ts
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import Project from "../../codewind/project/Project";
+import Requester from "../../codewind/project/Requester";
+
+export default async function toggleAutoInjectMetricsCmd(project: Project): Promise<void> {
+    return Requester.requestToggleAutoInjectMetrics(project);
+}

--- a/dev/src/command/webview/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/ProjectOverviewPage.ts
@@ -31,6 +31,7 @@ export enum ProjectOverviewWVMessages {
     UNBIND = "unbind",
     TOGGLE_ENABLEMENT = "toggleEnablement",
     EDIT = "edit",
+    TOGGLE_AUTOINJECTMETRICS = "toggleAutoInjectMetrics",
 }
 
 enum OpenableTypes {
@@ -125,6 +126,16 @@ function generateHtml(project: Project): string {
                         />
                     </td>
                 </tr>
+                <tr>
+                    <td class="info-label">Auto inject metrics:</td>
+                    <td>
+                        <input id="auto-inject-metrics-toggle" type="checkbox" class="btn"
+                            onclick="sendMsg('${ProjectOverviewWVMessages.TOGGLE_AUTOINJECTMETRICS}')"
+                            ${project.autoInjectMetricsEnabled ? "checked" : ""}
+                            ${project.state.isEnabled ? " " : " disabled"}
+                        />
+                    </td>
+                </tr>
                 ${buildRow("Application Status", project.state.appState)}
                 ${buildRow("Build Status", normalize(project.state.getBuildString(), NOT_AVAILABLE))}
                 ${buildRow("Last Image Build", normalizeDate(project.lastImgBuild, NOT_AVAILABLE))}
@@ -168,6 +179,8 @@ function generateHtml(project: Project): string {
 
             function sendMsg(type, data = undefined) {
                 // See IWebViewMsg in ProjectOverviewCmd
+                console.log('type', type);
+                console.log('data', data);
                 vscode.postMessage({ type: type, data: data });
             }
         </script>

--- a/dev/src/command/webview/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/ProjectOverviewPage.ts
@@ -179,8 +179,6 @@ function generateHtml(project: Project): string {
 
             function sendMsg(type, data = undefined) {
                 // See IWebViewMsg in ProjectOverviewCmd
-                console.log('type', type);
-                console.log('data', data);
                 vscode.postMessage({ type: type, data: data });
             }
         </script>

--- a/dev/src/constants/Commands.ts
+++ b/dev/src/constants/Commands.ts
@@ -49,6 +49,9 @@ enum Commands {
     PROJECT_OVERVIEW = "ext.cw.projectOverview",
     OPEN_APP_MONITOR = "ext.cw.openAppMonitor",
     OPEN_PERF_DASHBOARD = "ext.cw.openPerfDashboard",
+    TOGGLE_AUTOINJECTMETRICS = "ext.cw.toggleAutoInjectMetrics",
+    ENABLE_AUTOINJECTMETRICS = "ext.cw.enableAutoInjectMetrics",
+    DISABLE_AUTOINJECTMETRICS = "ext.cw.disableAutoInjectMetrics",
 
     MANAGE_LOGS = "ext.cw.manageLogs",
     SHOW_ALL_LOGS = "ext.cw.showAllLogs",

--- a/dev/src/constants/Endpoints.ts
+++ b/dev/src/constants/Endpoints.ts
@@ -43,6 +43,7 @@ export enum ProjectEndpoints {
     BUILD_ACTION = "build",
     LOGS = "logs",
     METRICS_STATUS = "metrics/status",
+    METRICS_INJECTION = "metrics/inject",
 
     OPEN = "open",
     CLOSE = "close",

--- a/dev/src/constants/strings/strings-en.json
+++ b/dev/src/constants/strings/strings-en.json
@@ -123,6 +123,8 @@
         "checkingAvailableLogs": "checking available logs",
         "togglingLogs": "toggling logs {{ onOrOff }}",
         "checkingMetrics": "checking metrics status",
+        "autoInjectMetricsEnable": "Enabling auto inject metrics",
+        "autoInjectMetricsDisable": "Disabling auto inject metrics",
 
         "requestSuccess":   "{{ projectName }}: {{ operationName }}",
         "requestFail":      "{{ projectName }}: {{ operationName }} failed: {{- err }}"

--- a/dev/src/view/TreeItemContext.ts
+++ b/dev/src/view/TreeItemContext.ts
@@ -59,6 +59,9 @@ enum TreeItemContextValues {
     PROJ_METRICS = "metricsAvailable",
 
     PROJ_SHELLABLE = "shellable",
+
+    PROJ_AUTOINJECTMETRICS_ON = "autoInjectMetricsOn",
+    PROJ_AUTOINJECTMETRICS_OFF = "autoInjectMetricsOff",
 }
 
 namespace TreeItemContext {
@@ -137,6 +140,12 @@ namespace TreeItemContext {
 
         if (project.canContainerShell) {
             contextValues.push(TreeItemContextValues.PROJ_SHELLABLE);
+        }
+
+        if (project.autoInjectMetricsEnabled) {
+            contextValues.push(TreeItemContextValues.PROJ_AUTOINJECTMETRICS_ON);
+        } else {
+            contextValues.push(TreeItemContextValues.PROJ_AUTOINJECTMETRICS_OFF);
         }
 
         // The final result will look like eg: "ext.cw.project.enabled.autoBuildOn"


### PR DESCRIPTION
Implements https://github.com/eclipse/codewind/issues/1290 for VSCode.
### Summary
* Add a check box to the project page which toggles the "auto inject metrics" functionality.
* Add a menu bar option to enable and disable it too.
Follows the same implementation as the "auto build" functionality.

### Testing
* manual testing through VSCode completed to check it shoes up.
* couldn't get the tests to run so will seek help as I'd like to add some. If there are already tests for the "auto build" stuff they should be easy to add.

### Screenshots
![image](https://user-images.githubusercontent.com/17385115/70058706-536c9b80-15d7-11ea-835c-3dfc34508419.png)

![image](https://user-images.githubusercontent.com/17385115/70058736-5ebfc700-15d7-11ea-8c19-513836996b2b.png)

Signed-off-by: James Wallis <james.wallis1@ibm.com>