### PR TITLE
Copy-out cwctl to ~/.codewind/version, not tmp

### DIFF
--- a/dev/src/codewind/connection/CLIWrapper.ts
+++ b/dev/src/codewind/connection/CLIWrapper.ts
@@ -61,19 +61,19 @@ namespace CLIWrapper {
 
         // The executable is copied out to eg ~/.codewind/0.7.0/cwctl
 
-        const binarySourcePath = getInternalExecutable();
-        const binarySourceDir = path.dirname(binarySourcePath);
-        const binaryBasename = path.basename(binarySourcePath);
+        const cwctlSourcePath = getInternalExecutable();
+        const binarySourceDir = path.dirname(cwctlSourcePath);
+        const cwctlBasename = path.basename(cwctlSourcePath);
 
         const binaryTargetDir = path.join(os.homedir(), Constants.DOT_CODEWIND_DIR, global.extVersion);
         await promisify(fs.mkdir)(binaryTargetDir, { recursive: true });
 
-        const cwctlTargetPath = path.join(binaryTargetDir, binaryBasename);
-        await copyIfDestNotExist(binarySourcePath, cwctlTargetPath);
+        const cwctlTargetPath = path.join(binaryTargetDir, cwctlBasename);
+        await copyIfDestNotExist(cwctlSourcePath, cwctlTargetPath);
         _cwctlPath = cwctlTargetPath;
 
         Log.d("Copying CLI prerequisites");
-        for (const prereq of CLI_PREREQS[binaryBasename]) {
+        for (const prereq of CLI_PREREQS[cwctlBasename]) {
             const source = path.join(binarySourceDir, prereq);
             const target = path.join(binaryTargetDir, prereq);
             await copyIfDestNotExist(source, target);

--- a/dev/src/codewind/connection/CLIWrapper.ts
+++ b/dev/src/codewind/connection/CLIWrapper.ts
@@ -21,6 +21,7 @@ import Log from "../../Logger";
 import { CLILifecycleWrapper } from "./local/CLILifecycleWrapper";
 import { CLILifecycleCommand } from "./local/CLILifecycleCommands";
 import { CLICommand } from "./CLICommandRunner";
+import Constants from "../../constants/Constants";
 
 const BIN_DIR = "bin";
 const CLI_EXECUTABLE = "cwctl";
@@ -47,38 +48,45 @@ namespace CLIWrapper {
     }
 
     // abs path to copied-out executable. Set and returned by initialize()
-    let _executablePath: string;
+    let _cwctlPath: string;
 
     /**
      * Copies the CLI to somewhere writeable if not already done, and sets exectablePath.
      * @returns The path to the CLI executable after moving it to a writeable directory.
      */
     export async function initialize(): Promise<string> {
-        if (_executablePath) {
-            return _executablePath;
+        if (_cwctlPath) {
+            return _cwctlPath;
         }
-        const executableDir = os.tmpdir();
-        const executable = getInternalExecutable();
-        const executableDirname = path.dirname(executable);
-        const executableBasename = path.basename(executable);
-        _executablePath = path.join(executableDir, executableBasename);
-        Log.d(`Copying ${executable} to ${_executablePath}`);
-        await promisify(fs.copyFile)(executable, path.join(executableDir, executableBasename));
+
+        // The executable is copied out to eg ~/.codewind/0.7.0/cwctl
+
+        const internalCwctl = getInternalExecutable();
+        const internalCwctlDirname = path.dirname(internalCwctl);
+        const internalCwctlBasename = path.basename(internalCwctl);
+
+        const cwctlTargetDir = path.join(os.homedir(), Constants.DOT_CODEWIND_DIR, global.extVersion);
+        await promisify(fs.mkdir)(cwctlTargetDir, { recursive: true });
+
+        _cwctlPath = path.join(cwctlTargetDir, internalCwctlBasename);
+        Log.d(`Copying ${internalCwctl} to ${_cwctlPath}`);
+        await promisify(fs.copyFile)(internalCwctl, path.join(cwctlTargetDir, internalCwctlBasename));
+
         Log.d("Copying CLI prerequisites");
-        for (const prereq of CLI_PREREQS[executableBasename]) {
-            const source = path.join(executableDirname, prereq);
-            const target = path.join(executableDir, prereq);
+        for (const prereq of CLI_PREREQS[internalCwctlBasename]) {
+            const source = path.join(internalCwctlDirname, prereq);
+            const target = path.join(cwctlTargetDir, prereq);
             Log.d(`Copying ${source} to ${target}`);
             await promisify(fs.copyFile)(source, target);
         }
-        Log.i("CLI copy-out succeeded, to " + _executablePath);
-        // cliOutputChannel.appendLine(`cwctl is available at ${_executablePath}`);
-        return _executablePath;
+        Log.i("CLI copy-out succeeded to " + _cwctlPath);
+        cliOutputChannel.appendLine(`cwctl is available at ${_cwctlPath}`);
+        return _cwctlPath;
     }
 
     export async function getExecutablePath(): Promise<string> {
-        if (_executablePath) {
-            return _executablePath;
+        if (_cwctlPath) {
+            return _cwctlPath;
         }
         return initialize();
     }
@@ -166,7 +174,7 @@ namespace CLIWrapper {
                             Log.e("Stderr:", errStr.trim());
                         }
 
-                        let errMsg = `Error running ${path.basename(_executablePath)} ${cmd.command.join(" ")}`;
+                        let errMsg = `Error running ${path.basename(_cwctlPath)} ${cmd.command.join(" ")}`;
                         if (cmd.hasJSONOutput && isProbablyJSON(outStr)) {
                             const asObj = JSON.parse(outStr);
                             if (asObj.error_description) {

--- a/dev/src/constants/Constants.ts
+++ b/dev/src/constants/Constants.ts
@@ -14,6 +14,7 @@
  */
 namespace Constants {
     export const PROJ_SETTINGS_FILE_NAME = ".cw-settings";
+    export const DOT_CODEWIND_DIR = ".codewind";
 
     export const CHE_WORKSPACEID_ENVVAR = "CHE_WORKSPACE_ID";
     export const CHE_API_EXTERNAL_ENVVAR = "CHE_API_EXTERNAL";

--- a/dev/src/extension.ts
+++ b/dev/src/extension.ts
@@ -42,12 +42,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     global.__extRoot = context.extensionPath;
     // Declared as 'any' type, but will always be assigned globalState which is a vscode.Memento
     global.extGlobalState = context.globalState;
-
-    // https://github.com/theia-ide/theia/issues/5501
     global.isTheia = vscode.env.appName.toLowerCase().includes("theia");
 
     Log.setLogFilePath(context);
     Log.i("Finished activating logger");
+
+    try {
+        const thisExtension = vscode.extensions.getExtension("IBM.codewind")!;
+        global.extVersion = thisExtension.packageJSON.version;
+    }
+    catch (err) {
+        Log.e("Error determining extension version", err);
+        global.extVersion = "unknown";
+    }
+    Log.i("Extension version is " + global.extVersion);
 
     try {
         await Translator.init();

--- a/dev/src/global.d.ts
+++ b/dev/src/global.d.ts
@@ -30,6 +30,11 @@ declare namespace NodeJS {
         // For some reason, importing anything at the top of this file causes all the properties declared here to not work anymore.
         // So, we use 'any' for extGlobalState - but it's a vscode.Memento.
         // extGlobalState: vscode.Memento
-        extGlobalState: any
+        extGlobalState: any,
+
+        /**
+         * The running version of this extension, eg "0.7.0"
+         */
+        extVersion: string,
     }
 }


### PR DESCRIPTION
Location is reported in Codewind output stream

https://github.com/eclipse/codewind/issues/1295

Signed-off-by: Tim Etchells <timetchells@ibm.com>