### PR TITLE
Fixes to Connection Settings page

### DIFF
--- a/dev/res/css/connection-overview.css
+++ b/dev/res/css/connection-overview.css
@@ -31,6 +31,11 @@ body {
     outline: none;
 }
 
+.info-label {
+    font-size: 110%;
+    font-weight: bold;
+}
+
 #url {
     font-size: 0.9rem;
     word-break: break-all;

--- a/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
@@ -63,6 +63,7 @@ export default class ConnectionOverview {
 
     public static showForExistingConnection(connection: RemoteConnection): ConnectionOverview {
         if (connection.overviewPage) {
+            connection.overviewPage.reveal();
             return connection.overviewPage;
         }
         return new ConnectionOverview(connection.memento, connection);
@@ -117,10 +118,12 @@ export default class ConnectionOverview {
         this.connectionOverviewPage.webview.html = html;
     }
 
+    public reveal(): void {
+        this.connectionOverviewPage.reveal();
+    }
+
     public dispose(): void {
-        if (this.connectionOverviewPage) {
-            this.connectionOverviewPage.dispose();
-        }
+        this.connectionOverviewPage.dispose();
     }
 
     private readonly handleWebviewMessage = async (msg: WebviewUtil.IWVMessage): Promise<void> => {

--- a/dev/src/command/webview/pages/ConnectionOverviewPage.ts
+++ b/dev/src/command/webview/pages/ConnectionOverviewPage.ts
@@ -47,33 +47,36 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
         <div style="display: flex;">
             <div id="deployment-box">
                 <h3>Codewind Connection
-                <div tabindex="0" id="learn-more-btn-remote">
-                    <a href=""><img class="learn-more-btn" alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a>
-                </div>
-                    ${isConnected ? `<img alt="remote connection" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionConnectedCheckmark)}"/>` :
-                    `<img alt="remote connection" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionDisconnectedCheckmark)}"/>`}
+                    <div tabindex="0" id="learn-more-btn-remote">
+                        <a href="https://codewind.dev"><img class="learn-more-btn" alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a>
+                    </div>
+                    ${isConnected ? `<img alt="Connected" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionConnectedCheckmark)}"/>` :
+                        `<img alt="Disconnected" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionDisconnectedCheckmark)}"/>`
+                    }
                 </h3>
                 <div class="input">
                     <p ${connectionExists ? "style='display: none;'" : ""}>Fill in the fields about the connection that you're starting from.</p>
-                    ${connectionExists ? `<label for="input-url">Codewind Gatekeeper URL</label>
-                    <img id="copy_url" onclick="copyURL(event)" alt="copy url" src="${WebviewUtil.getIcon(Resources.Icons.Copy)}"/><div id="copy_url_tooltip">Copied</div>`
-                    :
-                    `<label for="input-url">Codewind Gatekeeper URL</label>` }
+                    ${connectionExists ?
+`<label class="info-label" for="input-url">Codewind Gatekeeper URL</label>
+                        <img id="copy_url" onclick="copyURL(event)" alt="copy url" src="${WebviewUtil.getIcon(Resources.Icons.Copy)}"/><div id="copy_url_tooltip">Copied</div>`
+                        :
+                        `<label class="info-label" for="input-url">Codewind Gatekeeper URL</label>`
+                    }
                     <div id="url" ${connectionExists ? "" : "style='display: none;'"}>${connectionInfo.ingressUrl}</div>
                     <input type="text" id="ingress-url" class="input-url" name="ingress-url" placeholder="codewind-gatekeeper-mycluster.nip.io"
                         ${connectionExists ? "style='display: none;'" : ""}
                         value="${connectionInfo.ingressUrl ? connectionInfo.ingressUrl : ""}"/>
 
-                    <div style="float: left; margin-top: 10px;">
-                        <label for="input-username">Username</label>
+                    <div style="float: left; margin-top: 2em">
+                        <label class="info-label" for="input-username">Username</label>
                         <div id="ingress-username-label" ${connectionExists ? "" : "style='display: none;'"}>${connectionInfo.username}</div>
                         <input type="text" id="ingress-username" class="input-username" name="ingress-username"
                             ${connectionExists ? "style='display: none;'" : ""}
                             value='${connectionInfo.username || "developer"}'/>
                     </div>
-                    <div style="overflow: hidden; margin-top: 10px;">
+                    <div style="overflow: hidden; margin-top: 2em">
                         <div id="input-password" ${connectionExists ? "style='display: none;'" : ""}>
-                            <label for="input-password" style="margin-left: 10px;">Password</label>
+                            <label class="info-label" for="input-password" style="margin-left: 10px;">Password</label>
                             <input type="password" id="ingress-password" class="input-password" name="ingress-password" placeholder="**************"/>
                         </div>
                     </div>
@@ -83,15 +86,15 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
 
             <div>
                 <div id="link-container-box">
-                    <h3>Select Sources <a href=""><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
+                    <h3>Select Sources <a href="https://codewind.dev"><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
                     <p>Select sources to fetch new project templates from.</p><br>
                     <div type="button" class="btn btn-prominent" onclick=sendMsg("${ConnectionOverviewWVMessages.SOURCES}");>Open Template Source Manager</div>
                 </div>
 
                 <div id="link-container-box">
-                    <h3>Add Registries <a href=""><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
-                    <p> Log in to Container Image Registries to push project images and pull private template images.</p>
-                    <div type="button" class="btn btn-prominent" onclick=sendMsg("${ConnectionOverviewWVMessages.REGISTRY}");>Open Container Registry Manager (optional)</div>
+                    <h3>Add Registries <a href="https://codewind.dev"><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
+                    <p> (Optional) Log in to Container Image Registries to push project images and pull private template images.</p>
+                    <div type="button" class="btn btn-prominent" onclick=sendMsg("${ConnectionOverviewWVMessages.REGISTRY}");>Open Container Registry Manager</div>
                 </div>
             </div>
 

--- a/dev/src/command/webview/pages/RegistriesPage.ts
+++ b/dev/src/command/webview/pages/RegistriesPage.ts
@@ -107,7 +107,7 @@ function buildTable(registries: ContainerRegistry[], needsPushRegistry: boolean)
     if (registries.length === 0) {
         return `
             <h2 id="no-registries-msg">
-                You have not yet added any image registries. Click <a onclick="addNew()">Add New.</a> <br><br>
+                You have not yet added any image registries. Click <a title="Add New" onclick="addNew()">Add New.</a> <br><br>
                 ${needsPushRegistry ? "At least one image registry is required in order to build Codewind-style projects." : ""}
             </h2>
         `;


### PR DESCRIPTION
- Fix settings page not refocusing if already open
- Make labels stand out more, add more spacing
- Add links (just to codewind.dev for now, need updating)
- Fix title-text on Add New link
- Move "optional" from button

Signed-off-by: Tim Etchells <timetchells@ibm.com>