### PR TITLE
Choose performance- / application-container dash based on availabilit…

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -32,6 +32,8 @@ import { deleteProjectDir } from "../../command/project/RemoveProjectCmd";
 import { refreshProjectOverview } from "../../command/webview/pages/ProjectOverviewPage";
 import Constants from "../../constants/Constants";
 import Commands from "../../constants/Commands";
+import { getCodewindIngress } from "../../command/project/OpenPerfDashboard";
+import EndpointUtil from "../../constants/Endpoints";
 
 /**
  * Used to determine App Monitor URL
@@ -595,15 +597,27 @@ export default class Project implements vscode.QuickPickItem {
     public get appMonitorUrl(): string | undefined {
         const appMetricsPath = langToPathMap.get(this.type.language);
         const supported = appMetricsPath != null && this.capabilities.metricsAvailable;
-        Log.d(`${this.name} supports metrics ? ${supported}`);
-        if (!supported || !this.appUrl) {
+        if ((!this._injectMetricsEnabled) && supported) {
+            Log.d(`${this.name} supports metrics ? ${supported}`);
+            if (!monitorPageUrlStr.endsWith("/")) {
+                monitorPageUrlStr += "/";
+            }
+            let monitorPageUrlStr = this.appUrl.toString();
+            if (!monitorPageUrlStr.endsWith("/")) {
+                monitorPageUrlStr += "/";
+            }
+            return monitorPageUrlStr + appMetricsPath + "/?theme=dark";
+        }
+        try {
+            const cwBaseUrl = global.isTheia ? getCodewindIngress() : this.connection.url;
+            const dashboardUrl = EndpointUtil.getPerformanceMonitor(cwBaseUrl, this.language, this.id);
+            Log.d(`Monitor Dashboard url for ${this.name} is ${dashboardUrl}`);
+            return dashboardUrl.toString();
+        }
+        catch (err) {
+            vscode.window.showErrorMessage(MCUtil.errToString(err));
             return undefined;
         }
-        let monitorPageUrlStr = this.appUrl.toString();
-        if (!monitorPageUrlStr.endsWith("/")) {
-            monitorPageUrlStr += "/";
-        }
-        return monitorPageUrlStr + appMetricsPath + "/?theme=dark";
     }
 
     public get canContainerShell(): boolean {

--- a/dev/src/command/project/OpenPerfDashboard.ts
+++ b/dev/src/command/project/OpenPerfDashboard.ts
@@ -41,7 +41,7 @@ export default async function openPerformanceDashboard(project: Project): Promis
 
 const CW_INGRESS_NAME = "codewind";         // :(
 
-function getCodewindIngress(): vscode.Uri {
+export function getCodewindIngress(): vscode.Uri {
 
     // See https://github.com/eclipse/codewind-vscode/issues/123
     // Hopefully, this is temporary. This is how we assemble the URL to the codewind ingress/route without a kube/OC client.

--- a/dev/src/command/project/ToggleAutoInjectMetrics.ts
+++ b/dev/src/command/project/ToggleAutoInjectMetrics.ts
@@ -16,7 +16,7 @@ import Requester from "../../codewind/project/Requester";
 
 export default async function toggleInjectMetricsCmd(project: Project): Promise<void> {
     if (!project.type.canInjectMetrics) {
-        vscode.window.showWarningMessage(`This project type does not support Appmetrics injection.`);
+        vscode.window.showWarningMessage(`This project type does not support Codewind Application Metrics injection.`);
         return;
     }
     return Requester.requestToggleInjectMetrics(project);

--- a/dev/src/constants/Endpoints.ts
+++ b/dev/src/constants/Endpoints.ts
@@ -78,6 +78,15 @@ export namespace EndpointUtil {
             query: `project=${projectID}`,
         });
     }
+
+    export function getPerformanceMonitor(pfeUrl: vscode.Uri, projectLanguage: string, projectID: string): vscode.Uri {
+        // return value looks like http://localhost:9090/performance/monitor/dashboard/java?theme=dark&projectID=bacd4760-70ce-11e9-af94-d39edf21b705
+
+        return pfeUrl.with({
+            path: "/performance/monitor/dashboard/" + projectLanguage,
+            query: `theme=dark&projectID=${projectID}`,
+        });
+    }
 }
 
 export default EndpointUtil;

--- a/dev/src/constants/strings/strings-en.json
+++ b/dev/src/constants/strings/strings-en.json
@@ -123,8 +123,8 @@
         "checkingAvailableLogs": "checking available logs",
         "togglingLogs": "toggling logs {{ onOrOff }}",
         "checkingMetrics": "checking metrics status",
-        "autoInjectMetricsEnable": "Enabling appmetrics injection",
-        "autoInjectMetricsDisable": "Disabling appmetrics injection",
+        "autoInjectMetricsEnable": "Enabling Codewind Application Metrics injection",
+        "autoInjectMetricsDisable": "Disabling Codewind Application Metrics injection",
 
         "requestSuccess":   "{{ projectName }}: {{ operationName }}",
         "requestFail":      "{{ projectName }}: {{ operationName }} failed: {{- err }}"


### PR DESCRIPTION
…y of injected / provided metrics

Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR alters the return value of appMonitorUrl() to provide the performance-container dashboard link, unless we have not injected metrics and there is a dashboard in the application container, in which case the original application-container dashboard link is returned.

This PR is the `0.7.0` version of #346 