### PR TITLE
Fix context for errored connections

### DIFF
--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -133,7 +133,7 @@
 
     "// None of items below are exposed to user": [
         "These regexes match Context IDs for Projects and Connections to determine command enablement",
-        "See TreeItemFactory for how the Context IDs are set"
+        "See TreeItemFactory / TreeItemContext for how the Context IDs are set"
     ],
 
     "isTreeRoot": "viewItem == ext.cw.root",
@@ -142,13 +142,13 @@
     "isStartedLocalCodewind": "viewItem =~ /.*local\\.started.*/",
 
     "isConnection": "viewItem =~ /ext\\.cw\\.connection\\.*/",
-    "isConnectedConnection": "viewItem =~ /ext\\.cw\\.connection\\..*connected.*/",
+    "isConnectedConnection": "viewItem =~ /ext\\.cw\\.connection\\..*connection-good.*/",
     "isRemoteConnection": "viewItem =~ /ext\\.cw\\.connection\\.remote.*/",
-    "isDisconnectedRemoteConnection": "viewItem =~ /ext\\.cw\\.connection\\.remote\\..*\\.disconnected.*/",
+    "isDisconnectedRemoteConnection": "viewItem =~ /ext\\.cw\\.connection\\.remote\\.enabled\\.connection-bad.*/",
     "isEnabledRemoteConnection": "viewItem =~ /ext\\.cw\\.connection\\.remote\\.enabled.*/",
     "isDisabledRemoteConnection": "viewItem =~ /ext\\.cw\\.connection\\.remote\\.disabled.*/",
-    "isConnectionWithRegistry": "viewItem =~ /ext\\.cw\\.connection.*\\.registry.*connected.*/",
-    "isConnectionWithTekton": "viewItem =~ /ext\\.cw\\.connection.*\\.tekton.*connected.*/",
+    "isConnectionWithRegistry": "viewItem =~ /ext\\.cw\\.connection.*\\.registry.*/",
+    "isConnectionWithTekton": "viewItem =~ /ext\\.cw\\.connection.*\\.tekton.*/",
 
     "isProject":                        "viewItem =~ /ext\\.cw\\.project.*/",
     "isEnabledProject":                 "viewItem =~ /ext\\.cw\\.project\\.enabled.*/",

--- a/dev/src/view/TreeItemContext.ts
+++ b/dev/src/view/TreeItemContext.ts
@@ -32,8 +32,9 @@ enum TreeItemContextValues {
 
     // Connection
     CONN_BASE = "connection",
-    CONN_CONNECTED = "connected",
-    CONN_DISCONNECTED = "disconnected",
+    CONN_CONNECTED = "connection-good",
+    // CONN_CONNECTED must not be a substring of CONN_DISCONNECTED
+    CONN_DISCONNECTED = "connection-bad",
     REMOTECONN_ENABLED = "remote.enabled",
     REMOTECONN_DISABLED = "remote.disabled",
 
@@ -89,12 +90,11 @@ namespace TreeItemContext {
             }
         }
 
-        if (connection.isKubeConnection) {
-            contextValues.push(TreeItemContextValues.CONN_WITH_TEKTON);
-            contextValues.push(TreeItemContextValues.CONN_WITH_REGISTRY);
-        }
-
         if (connection.isConnected) {
+            if (connection.isKubeConnection) {
+                contextValues.push(TreeItemContextValues.CONN_WITH_TEKTON);
+                contextValues.push(TreeItemContextValues.CONN_WITH_REGISTRY);
+            }
             contextValues.push(TreeItemContextValues.CONN_CONNECTED);
         }
         else if (connection.enabled) {


### PR DESCRIPTION
Removes create project, add project commands from disconnected connections
Bug introduced by https://github.com/eclipse/codewind-vscode/pull/336

Signed-off-by: Tim Etchells <timetchells@ibm.com>