### PR TITLE
fix: show warning rather than open app monitor when project stopped

### DIFF
--- a/dev/src/command/project/OpenAppMonitor.ts
+++ b/dev/src/command/project/OpenAppMonitor.ts
@@ -21,7 +21,7 @@ import CodewindEventListener from "../../codewind/connection/CodewindEventListen
 
 export default async function openAppMonitorCmd(project: Project): Promise<void> {
     try {
-        if (project.appUrl == null) {
+        if (!(project.state.isStarted || project.state.isStarting)) {
             vscode.window.showWarningMessage(`Cannot open application monitor - ${project.name} is not currently running.`);
             return;
         }


### PR DESCRIPTION
**Current Behavior**
When a project is not running, it cannot provide metrics. Before the project has built _for the first time_, when the user clicks the `open app monitor` button, they see an appropriate warning (`Cannot open application monitor - ${project.name} is not currently running.`)

But if the user rebuilds the project (e.g. by injecting metrics or removing injected metrics), and clicks the `open app monitor` button, they do not see any warning, and the VSCode IDE opens the app monitor dash, which in the case of `<user project origin>/appmetrics-dash` will be a 404 Not Found page (because the project is not running yet).

**Expected Behavior**
The user should see a warning in this scenario. (The Eclipse IDE already does this)

**Solution**
If the project is not running, send this warning

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>