### PR TITLE
Allow metrics injection to refresh the app monitor capabilities

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -597,8 +597,7 @@ export default class Project implements vscode.QuickPickItem {
     public get appMonitorUrl(): string | undefined {
         const appMetricsPath = langToPathMap.get(this.type.language);
         const supported = appMetricsPath != null && this.capabilities.metricsAvailable;
-        if ((!this._injectMetricsEnabled) && supported && 
-            !(this.type.type === ProjectType.Types.GENERIC_DOCKER && this.type.language === 'java')) {
+        if ((!this._injectMetricsEnabled) && supported ) {
             // open app monitor in Application container
             Log.d(`${this.name} supports metrics ? ${supported}`);
             if (this.appUrl === undefined) {

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -597,7 +597,9 @@ export default class Project implements vscode.QuickPickItem {
     public get appMonitorUrl(): string | undefined {
         const appMetricsPath = langToPathMap.get(this.type.language);
         const supported = appMetricsPath != null && this.capabilities.metricsAvailable;
-        if ((!this._injectMetricsEnabled) && supported) {
+        if ((!this._injectMetricsEnabled) && supported && 
+            !(this.type.type === ProjectType.Types.GENERIC_DOCKER && this.type.language === 'java')) {
+            // open app monitor in Application container
             Log.d(`${this.name} supports metrics ? ${supported}`);
             if (this.appUrl === undefined) {
                 return undefined;
@@ -609,6 +611,7 @@ export default class Project implements vscode.QuickPickItem {
             return monitorPageUrlStr + appMetricsPath + "/?theme=dark";
         }
         try {
+            // open app monitor in Performance container
             const cwBaseUrl = global.isTheia ? getCodewindIngress() : this.connection.url;
             const dashboardUrl = EndpointUtil.getPerformanceMonitor(cwBaseUrl, this.language, this.id);
             Log.d(`Monitor Dashboard url for ${this.name} is ${dashboardUrl}`);
@@ -730,7 +733,7 @@ export default class Project implements vscode.QuickPickItem {
         return changed;
     }
 
-    public setInjectMetrics(newInjectMetrics: boolean | undefined): boolean {
+    public async setInjectMetrics(newInjectMetrics: boolean | undefined): Promise<boolean> {
         if (newInjectMetrics == null) {
             return false;
         }
@@ -741,6 +744,7 @@ export default class Project implements vscode.QuickPickItem {
         if (changed) {
             // onChange has to be invoked explicitly because this function can be called outside of update()
             Log.d(`New autoInjectMetricsEnabled for ${this.name} is ${this._injectMetricsEnabled}`);
+            this.capabilities.metricsAvailable = await Requester.areMetricsAvailable(this);
             this.onChange();
         }
 

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -320,7 +320,7 @@ namespace Requester {
         return new ProjectCapabilities(result.startModes, result.controlCommands, metricsAvailable);
     }
 
-    async function areMetricsAvailable(project: Project): Promise<boolean> {
+    export async function areMetricsAvailable(project: Project): Promise<boolean> {
         const msg = Translator.t(STRING_NS, "checkingMetrics");
         const res = await doProjectRequest(project, ProjectEndpoints.METRICS_STATUS, {}, "GET", msg, true);
         return res.metricsAvailable;
@@ -338,7 +338,7 @@ namespace Requester {
         };
 
         await doProjectRequest(project, ProjectEndpoints.METRICS_INJECTION, body, "POST", newAutoInjectMetricsUserStr);
-        project.setInjectMetrics(newInjectMetrics);
+        await project.setInjectMetrics(newInjectMetrics);
     }
 
     /**

--- a/dev/src/view/TreeItemContext.ts
+++ b/dev/src/view/TreeItemContext.ts
@@ -138,7 +138,7 @@ namespace TreeItemContext {
             contextValues.push(TreeItemContextValues.PROJ_RESTARTABLE);
         }
 
-        if (project.capabilities.metricsAvailable) {
+        if (project.capabilities.metricsAvailable || project.language === 'java') {
             contextValues.push(TreeItemContextValues.PROJ_METRICS);
         }
 


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR allows VSCode to update the project dashboard capabilities when inject metrics is toggled, to allow a project that previously had no dashboard to be able to display the 'Open App Monitor' link in the context menu.

This is the `0.7.0` version of #355 