### PR TITLE
Update versions, refactor Webviews

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "codewind",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -5,7 +5,7 @@
     "version": "0.8.0",
     "publisher": "IBM",
     "engines": {
-        "vscode": "^1.28.0"
+        "vscode": "^1.38.0"
     },
     "license": "EPL-2.0",
     "bugs": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,7 +2,7 @@
     "name": "codewind",
     "displayName": "%displayName%",
     "description": "%description%",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "publisher": "IBM",
     "engines": {
         "vscode": "^1.28.0"

--- a/dev/src/MCUtil.ts
+++ b/dev/src/MCUtil.ts
@@ -113,6 +113,7 @@ namespace MCUtil {
         return s.toLowerCase()
             .replace(/\s+/g, "-")           // spaces to -
             .replace(/\./g, "-")            // literal . to -
+            .replace(/\(|\)/g, "")           // remove ( and )
             .replace(toRemoveRx, "")        // remove other special chars
             // .replace(/[^\w\-]+/g, "")    // remove all non-words
             .replace(/\-\-+/g, "-")         // replace multiple - with single

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -25,8 +25,8 @@ import CodewindEventListener, { OnChangeCallbackArgs } from "./CodewindEventList
 import CLIWrapper from "./CLIWrapper";
 import { ConnectionStates, ConnectionState } from "./ConnectionState";
 import { CLICommandRunner } from "./CLICommandRunner";
-import { ManageSourcesPage as SourcesPageWrapper , ITemplateSource } from "../../command/webview/SourcesPageWrapper";
-import { ManageRegistriesPageWrapper as RegistriesPageWrapper, ManageRegistriesPageWrapper } from "../../command/webview/RegistriesPageWrapper";
+import { SourcesPageWrapper, ITemplateSource } from "../../command/webview/SourcesPageWrapper";
+import { RegistriesPageWrapper } from "../../command/webview/RegistriesPageWrapper";
 
 export const LOCAL_CONNECTION_ID = "local";
 
@@ -399,7 +399,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         this._sourcesPage = page;
     }
 
-    public onDidOpenRegistriesPage(page: ManageRegistriesPageWrapper): void {
+    public onDidOpenRegistriesPage(page: RegistriesPageWrapper): void {
         this._registriesPage = page;
     }
 
@@ -407,7 +407,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         return this._sourcesPage;
     }
 
-    public get registriesPage(): ManageRegistriesPageWrapper | undefined {
+    public get registriesPage(): RegistriesPageWrapper | undefined {
         return this._registriesPage;
     }
 

--- a/dev/src/codewind/connection/RemoteConnection.ts
+++ b/dev/src/codewind/connection/RemoteConnection.ts
@@ -12,7 +12,7 @@
 import * as vscode from "vscode";
 
 import Connection from "./Connection";
-import ConnectionOverview from "../../command/webview/ConnectionOverviewPageWrapper";
+import ConnectionOverviewWrapper from "../../command/webview/ConnectionOverviewPageWrapper";
 import { ConnectionStates, ConnectionState } from "./ConnectionState";
 import { CLICommandRunner, AccessToken } from "./CLICommandRunner";
 import Log from "../../Logger";
@@ -28,7 +28,7 @@ export default class RemoteConnection extends Connection {
     // private _username: string | undefined;
     private _accessToken: AccessToken | undefined;
 
-    private _activeOverviewPage: ConnectionOverview | undefined;
+    private _activeOverviewPage: ConnectionOverviewWrapper | undefined;
 
     /**
      * Do not allow toggling (enabling or disabling) the connection when a toggle is already in progress
@@ -238,11 +238,11 @@ export default class RemoteConnection extends Connection {
         await this.enable();
     }
 
-    public get overviewPage(): ConnectionOverview | undefined {
+    public get overviewPage(): ConnectionOverviewWrapper | undefined {
         return this._activeOverviewPage;
     }
 
-    public onDidOpenOverview(overviewPage: ConnectionOverview): void {
+    public onDidOpenOverview(overviewPage: ConnectionOverviewWrapper): void {
         this._activeOverviewPage = overviewPage;
     }
 
@@ -254,7 +254,7 @@ export default class RemoteConnection extends Connection {
 
     public tryRefreshOverview(): void {
         if (this._activeOverviewPage) {
-            this._activeOverviewPage.refresh(this.memento);
+            this._activeOverviewPage.refresh();
         }
     }
 }

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -476,6 +476,7 @@ export default class Project implements vscode.QuickPickItem {
 
     public onDidCloseOverviewPage(): void {
         this._overviewPage?.dispose();
+        this._overviewPage = undefined;
     }
 
     ///// Getters
@@ -596,6 +597,7 @@ export default class Project implements vscode.QuickPickItem {
             return dashboardUrl.toString();
         }
         catch (err) {
+            Log.e("Error determining monitor dashboard URL", err);
             vscode.window.showErrorMessage(MCUtil.errToString(err));
             return undefined;
         }

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -29,11 +29,11 @@ import SocketEvents from "../connection/SocketEvents";
 import Validator from "./Validator";
 import Requester from "./Requester";
 import { deleteProjectDir } from "../../command/project/RemoveProjectCmd";
-import { refreshProjectOverview } from "../../command/webview/pages/ProjectOverviewPage";
 import Constants from "../../constants/Constants";
 import Commands from "../../constants/Commands";
-import { getCodewindIngress } from "../../command/project/OpenPerfDashboard"
-import EndpointUtil from "../../constants/Endpoints"
+import { getCodewindIngress } from "../../command/project/OpenPerfDashboard";
+import EndpointUtil from "../../constants/Endpoints";
+import ProjectOverviewPageWrapper from "../../command/webview/ProjectOverviewPageWrapper";
 
 /**
  * Used to determine App Monitor URL
@@ -94,7 +94,7 @@ export default class Project implements vscode.QuickPickItem {
 
     // Active ProjectInfo webviewPanel. Only one per project. Undefined if no project overview page is active.
     // Track this so we can refresh it when update() is called, and prevent multiple webviews being open for one project.
-    private activeProjectInfo: vscode.WebviewPanel | undefined;
+    private _overviewPage: ProjectOverviewPageWrapper | undefined;
 
     public readonly logManager: MCLogManager;
 
@@ -236,7 +236,7 @@ export default class Project implements vscode.QuickPickItem {
      */
     private onChange(): void {
         this.connection.onChange(this);
-        this.tryRefreshProjectInfoPage();
+        this._overviewPage?.refresh();
     }
 
     /**
@@ -416,7 +416,7 @@ export default class Project implements vscode.QuickPickItem {
         await Promise.all([
             this.clearValidationErrors(),
             this.logManager.destroyAllLogs(),
-            this.activeProjectInfo != null ? this.activeProjectInfo.dispose() : Promise.resolve(),
+            this._overviewPage != null ? this._overviewPage.dispose() : Promise.resolve(),
         ]);
         this.connection.onChange(this);
     }
@@ -466,35 +466,16 @@ export default class Project implements vscode.QuickPickItem {
 
     ///// ProjectOverview
 
-    /**
-     * To be called when the user tries to open this project's Project Info page.
-     *
-     * If the user already has a Project Info page open for this project, returns the existing page.
-     * In this case, the webview should be re-revealed, but a new one should not be created.
-     * If the user does not already have an info page open for this project, returns undefined,
-     * and sets the given webview to be this project's project info panel.
-     */
-    public onDidOpenProjectInfo(wvPanel: vscode.WebviewPanel): vscode.WebviewPanel | undefined {
-        if (this.activeProjectInfo != null) {
-            return this.activeProjectInfo;
-        }
-        // Log.d(`Info opened for project ${this.name}`);
-        this.activeProjectInfo = wvPanel;
-        return undefined;
+    public onDidOpenOverviewPage(overviewPage: ProjectOverviewPageWrapper): void {
+        this._overviewPage = overviewPage;
     }
 
-    public onDidCloseProjectInfo(): void {
-        if (this.activeProjectInfo != null) {
-            this.activeProjectInfo.dispose();
-            this.activeProjectInfo = undefined;
-        }
+    public get overviewPage(): ProjectOverviewPageWrapper | undefined {
+        return this._overviewPage;
     }
 
-    private tryRefreshProjectInfoPage(): void {
-        if (this.activeProjectInfo != null) {
-            // Log.d("Refreshing projectinfo");
-            refreshProjectOverview(this.activeProjectInfo, this);
-        }
+    public onDidCloseOverviewPage(): void {
+        this._overviewPage?.dispose();
     }
 
     ///// Getters
@@ -618,7 +599,7 @@ export default class Project implements vscode.QuickPickItem {
             vscode.window.showErrorMessage(MCUtil.errToString(err));
             return undefined;
         }
-        
+
     }
 
     public get canContainerShell(): boolean {

--- a/dev/src/codewind/project/ProjectType.ts
+++ b/dev/src/codewind/project/ProjectType.ts
@@ -19,7 +19,7 @@ export class ProjectType {
     // public readonly userFriendlyType: string;
     public readonly debugType: ProjectType.DebugTypes | undefined;
 
-    public readonly icon: Resources.IconPaths;
+    public readonly icon: Resources.Icons;
 
     constructor(
         public readonly internalType: ProjectType.InternalTypes,
@@ -93,30 +93,30 @@ export class ProjectType {
         }
     }
 
-    private static getProjectIcon(type: ProjectType.Types, language: string): Resources.IconPaths {
+    private static getProjectIcon(type: ProjectType.Types, language: string): Resources.Icons {
         switch (language.toLowerCase()) {
             case this.Languages.JAVA:
                 if (type === ProjectType.Types.MICROPROFILE) {
-                    return Resources.getIconPaths(Resources.Icons.Microprofile);
+                    return Resources.Icons.Microprofile;
                 }
                 else if (type === ProjectType.Types.SPRING) {
-                    return Resources.getIconPaths(Resources.Icons.Spring);
+                    return Resources.Icons.Spring;
                 }
                 else {
-                    return Resources.getIconPaths(Resources.Icons.Java);
+                    return Resources.Icons.Java;
                 }
             case this.Languages.NODE:
             case "javascript":
             case "js":
-                return Resources.getIconPaths(Resources.Icons.NodeJS);
+                return Resources.Icons.NodeJS;
             case this.Languages.SWIFT:
-                return Resources.getIconPaths(Resources.Icons.Swift);
+                return Resources.Icons.Swift;
             case this.Languages.PYTHON:
-                return Resources.getIconPaths(Resources.Icons.Python);
+                return Resources.Icons.Python;
             case this.Languages.GO:
-                return Resources.getIconPaths(Resources.Icons.Go);
+                return Resources.Icons.Go;
             default:
-                return Resources.getIconPaths(Resources.Icons.Generic);
+                return Resources.Icons.Generic;
         }
     }
 

--- a/dev/src/codewind/project/Validator.ts
+++ b/dev/src/codewind/project/Validator.ts
@@ -34,7 +34,7 @@ namespace Validator {
         // unfortunately vscode gives an error that it can't be opened when clicked, so this can likely be improved
         const diagnosticUri: vscode.Uri = project.localPath;
 
-        const oldDiagnostics: vscode.Diagnostic[] = Project.diagnostics.get(diagnosticUri) || [];
+        const oldDiagnostics: readonly vscode.Diagnostic[] = Project.diagnostics.get(diagnosticUri) || [];
         const newDiagnostics: vscode.Diagnostic[] = [];
 
         // For each validation problem, see if we already have an error for it. If so, do nothing.

--- a/dev/src/command/connection/ConnectionOverviewCmd.ts
+++ b/dev/src/command/connection/ConnectionOverviewCmd.ts
@@ -13,7 +13,7 @@ import * as vscode from "vscode";
 
 import Connection from "../../codewind/connection/Connection";
 import RemoteConnection from "../../codewind/connection/RemoteConnection";
-import ConnectionOverview from "../webview/ConnectionOverviewPageWrapper";
+import ConnectionOverviewWrapper from "../webview/ConnectionOverviewPageWrapper";
 
 export default async function remoteConnectionOverviewCmd(connection: Connection): Promise<void> {
     // if (!(connection instanceof RemoteConnection)) {
@@ -23,5 +23,5 @@ export default async function remoteConnectionOverviewCmd(connection: Connection
     }
 
     const remoteConnection = connection as RemoteConnection;
-    ConnectionOverview.showForExistingConnection(remoteConnection);
+    ConnectionOverviewWrapper.showForExistingConnection(remoteConnection);
 }

--- a/dev/src/command/connection/ManageRegistriesCmd.ts
+++ b/dev/src/command/connection/ManageRegistriesCmd.ts
@@ -15,7 +15,7 @@ import * as vscode from "vscode";
 import Connection from "../../codewind/connection/Connection";
 import Log from "../../Logger";
 import MCUtil from "../../MCUtil";
-import { ManageRegistriesPageWrapper } from "../webview/RegistriesPageWrapper";
+import { RegistriesPageWrapper } from "../webview/RegistriesPageWrapper";
 
 export default async function manageRegistriesCmd(connection: Connection): Promise<void> {
     if (!connection.isKubeConnection) {
@@ -29,11 +29,11 @@ export default async function manageRegistriesCmd(connection: Connection): Promi
             connection.registriesPage.reveal();
             return;
         }
-        const manageRegistriesPage = new ManageRegistriesPageWrapper(connection);
-        connection.onDidOpenRegistriesPage(manageRegistriesPage);
+        // tslint:disable-next-line: no-unused-expression
+        new RegistriesPageWrapper(connection);
     }
     catch (err) {
-        const errMsg = `Error opening Manage image registries page:`;
+        const errMsg = `Error opening Image Registries page:`;
         vscode.window.showErrorMessage(`${errMsg} ${MCUtil.errToString(err)}`);
         Log.e(errMsg, err);
     }

--- a/dev/src/command/connection/ManageSourcesCmd.ts
+++ b/dev/src/command/connection/ManageSourcesCmd.ts
@@ -14,7 +14,7 @@ import * as vscode from "vscode";
 import Connection from "../../codewind/connection/Connection";
 import Log from "../../Logger";
 import MCUtil from "../../MCUtil";
-import { ManageSourcesPage } from "../webview/SourcesPageWrapper";
+import { SourcesPageWrapper } from "../webview/SourcesPageWrapper";
 
 export default async function manageSourcesCmd(connection: Connection): Promise<void> {
     try {
@@ -24,8 +24,8 @@ export default async function manageSourcesCmd(connection: Connection): Promise<
             return;
         }
 
-        const manageSourcesPage = new ManageSourcesPage(connection);
-        connection.onDidOpenSourcesPage(manageSourcesPage);
+        // tslint:disable-next-line: no-unused-expression
+        new SourcesPageWrapper(connection);
     }
     catch (err) {
         const errMsg = `Error opening Manage Template Sources page:`;

--- a/dev/src/command/connection/NewConnectionCmd.ts
+++ b/dev/src/command/connection/NewConnectionCmd.ts
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 import * as vscode from "vscode";
-import ConnectionOverview from "../webview/ConnectionOverviewPageWrapper";
+import ConnectionOverviewWrapper from "../webview/ConnectionOverviewPageWrapper";
 
 const NEW_CONNECTION_TITLE = "New Codewind Connection";
 // const NEW_CONNECTION_NO_STEPS = 2;
@@ -48,7 +48,7 @@ export async function newRemoteConnectionCmd(): Promise<void> {
     if (!connectionLabel) {
         return;
     }
-    ConnectionOverview.showForNewConnection(connectionLabel);
+    ConnectionOverviewWrapper.showForNewConnection(connectionLabel);
 }
 
 async function getConnectionLabel(): Promise<string | undefined> {

--- a/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
@@ -91,9 +91,7 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
     }
 
     protected onDidDispose(): void {
-        if (this.connection) {
-            this.connection.onDidCloseOverview();
-        }
+        this.connection?.onDidCloseOverview();
     }
 
     protected readonly handleWebviewMessage = async (msg: WebviewUtil.IWVMessage): Promise<void> => {

--- a/dev/src/command/webview/ProjectOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ProjectOverviewPageWrapper.ts
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import { WebviewWrapper, WebviewResourceProvider } from "./WebviewWrapper";
+import WebviewUtil from "./WebviewUtil";
+import Project from "../../codewind/project/Project";
+import toggleInjectMetricsCmd from "../project/ToggleAutoInjectMetrics";
+import Log from "../../Logger";
+import toggleAutoBuildCmd from "../project/ToggleAutoBuildCmd";
+import toggleEnablementCmd from "../project/ToggleEnablementCmd";
+import requestBuildCmd from "../project/RequestBuildCmd";
+import { removeProject } from "../project/RemoveProjectCmd";
+import { getProjectOverviewHtml } from "./pages/ProjectOverviewPage";
+
+export enum ProjectOverviewWVMessages {
+    BUILD = "build",
+    TOGGLE_AUTOBUILD = "toggleAutoBuild",
+    OPEN = "open",
+    UNBIND = "unbind",
+    TOGGLE_ENABLEMENT = "toggleEnablement",
+    EDIT = "edit",
+    TOGGLE_INJECT_METRICS = "toggleInjectMetrics",
+}
+
+export default class ProjectOverviewPageWrapper extends WebviewWrapper {
+
+    constructor(
+        private readonly project: Project,
+    ) {
+        super(project.name, project.type.icon);
+        project.onDidOpenOverviewPage(this);
+        this.refresh();
+    }
+
+    protected async generateHtml(resourceProvider: WebviewResourceProvider): Promise<string> {
+        return getProjectOverviewHtml(resourceProvider, this.project);
+    }
+
+    protected onDidDispose(): void {
+        this.project.onDidCloseOverviewPage();
+    }
+
+    protected handleWebviewMessage = async (msg: WebviewUtil.IWVMessage): Promise<void> => {
+        switch (msg.type as ProjectOverviewWVMessages) {
+            case ProjectOverviewWVMessages.OPEN: {
+                WebviewUtil.onRequestOpen(msg);
+                break;
+            }
+            case ProjectOverviewWVMessages.TOGGLE_AUTOBUILD: {
+                toggleAutoBuildCmd(this.project);
+                break;
+            }
+            case ProjectOverviewWVMessages.TOGGLE_ENABLEMENT: {
+                toggleEnablementCmd(this.project);
+                break;
+            }
+            case ProjectOverviewWVMessages.BUILD: {
+                requestBuildCmd(this.project);
+                break;
+            }
+            case ProjectOverviewWVMessages.UNBIND: {
+                removeProject(this.project);
+                break;
+            }
+            case ProjectOverviewWVMessages.EDIT: {
+                this.project.tryOpenSettingsFile();
+                break;
+            }
+            case ProjectOverviewWVMessages.TOGGLE_INJECT_METRICS: {
+                toggleInjectMetricsCmd(this.project);
+                break;
+            }
+            default: {
+                Log.e("Received unknown event from project info webview:", msg);
+            }
+        }
+    }
+}

--- a/dev/src/command/webview/WebviewWrapper.ts
+++ b/dev/src/command/webview/WebviewWrapper.ts
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import * as vscode from "vscode";
+
+import Resources from "../../constants/Resources";
+import WebviewUtil from "./WebviewUtil";
+import Log from "../../Logger";
+import MCUtil from "../../MCUtil";
+
+export interface WebviewResourceProvider {
+    getStylesheet(path: string): string;
+    getIcon(icon: Resources.Icons): string;
+}
+
+export abstract class WebviewWrapper {
+
+    protected readonly webPanel: vscode.WebviewPanel;
+    private readonly resourceProvider: WebviewResourceProvider;
+
+    /**
+     * Create and open the webview.
+     * Subclass must call `this.refresh()` after performing all initialization.
+     */
+    constructor(
+        protected readonly title: string,
+        titleIcon: Resources.Icons,
+    ) {
+        this.webPanel = vscode.window.createWebviewPanel(title, title, vscode.ViewColumn.Active, WebviewUtil.getWebviewOptions());
+
+        this.webPanel.reveal();
+        this.webPanel.onDidDispose(() => {
+            this.onDidDispose();
+        });
+
+        this.webPanel.iconPath = Resources.getIconPaths(titleIcon);
+
+        this.webPanel.webview.onDidReceiveMessage((msg: WebviewUtil.IWVMessage) => {
+            try {
+                this.handleWebviewMessage(msg);
+            }
+            catch (err) {
+                vscode.window.showErrorMessage(`${this.title}: Error running action ${msg.type} - ${MCUtil.errToString(err)}`);
+                Log.e(`Error processing message from webview ${this.title}`, err);
+                Log.e("Message was", msg);
+            }
+        });
+
+        this.resourceProvider = {
+            getIcon: (icon: Resources.Icons) => {
+                const fsPath = Resources.getIconPaths(icon).dark;
+                return this.webPanel.webview.asWebviewUri(fsPath).toString();
+            },
+            getStylesheet: (filename: string) => {
+                const fsPath = Resources.getCss(filename);
+                return this.webPanel.webview.asWebviewUri(fsPath).toString();
+            }
+        };
+    }
+
+    public reveal(): void {
+        this.webPanel.reveal();
+    }
+
+    public dispose(): void {
+        this.webPanel.dispose();
+        this.onDidDispose();
+    }
+
+    public async refresh(): Promise<void> {
+        let newHtml;
+        try {
+            newHtml = await this.generateHtml(this.resourceProvider);
+        }
+        catch (err) {
+            const errMsg = `Error with wizard page ${this.title}:`;
+            Log.e(errMsg, err);
+            vscode.window.showErrorMessage(`${errMsg} ${MCUtil.errToString(err)}`);
+            return;
+        }
+
+        WebviewUtil.debugWriteOutWebview(newHtml, `${MCUtil.slug(this.title)}.html`);
+        // Setting the html to "" seems to clear the page state, otherwise there is some caching done
+        // which causes eg. the selected radiobutton to not be updated https://github.com/eclipse/codewind/issues/1413
+        this.webPanel.webview.html = "";
+        this.webPanel.webview.html = newHtml;
+    }
+
+    protected async abstract generateHtml(resourceProvider: WebviewResourceProvider): Promise<string>;
+
+    protected abstract readonly handleWebviewMessage: (msg: WebviewUtil.IWVMessage) => void | Promise<void>;
+
+    protected abstract onDidDispose(): void | Promise<void>;
+}

--- a/dev/src/command/webview/pages/ConnectionOverviewPage.ts
+++ b/dev/src/command/webview/pages/ConnectionOverviewPage.ts
@@ -15,8 +15,9 @@ import Resources from "../../../constants/Resources";
 import WebviewUtil from "../WebviewUtil";
 import { ConnectionOverviewWVMessages, ConnectionOverviewFields } from "../ConnectionOverviewPageWrapper";
 import CWDocs from "../../../constants/CWDocs";
+import { WebviewResourceProvider } from "../WebviewWrapper";
 
-export default function getConnectionInfoHtml(connectionInfo: ConnectionOverviewFields, isConnected: boolean): string {
+export default function getConnectionInfoHtml(rp: WebviewResourceProvider, connectionInfo: ConnectionOverviewFields, isConnected: boolean): string {
     // If the ingress URL has been saved, then we have created the connection and we are now viewing or editing it.
     const connectionExists = !!connectionInfo.ingressUrl;
     return `
@@ -27,16 +28,16 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         ${WebviewUtil.getCSP()}
 
-        <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("connection-overview.css")}"/>
-        <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("common.css")}"/>
+        <link rel="stylesheet" href="${rp.getStylesheet("connection-overview.css")}"/>
+        <link rel="stylesheet" href="${rp.getStylesheet("common.css")}"/>
         ${global.isTheia ?
-            `<link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("theia.css")}"/>` : ""}
+            `<link rel="stylesheet" href="${rp.getStylesheet("theia.css")}"/>` : ""}
     </head>
     <body>
     <div id="top-section">
         <div class="title-section">
             <img id="connection-logo" alt="Codewind Logo"
-                src="${isConnected ? WebviewUtil.getIcon(Resources.Icons.ConnectionConnected) : WebviewUtil.getIcon(Resources.Icons.ConnectionDisconnected)}"/>
+                src="${isConnected ? rp.getIcon(Resources.Icons.ConnectionConnected) : rp.getIcon(Resources.Icons.ConnectionDisconnected)}"/>
             <div id="remote-connection-name" class="connection-name">${connectionInfo.label}</div>
         </div>
     </div>
@@ -49,17 +50,17 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
             <div id="deployment-box">
                 <h3>Codewind Connection
                     <div tabindex="0" id="learn-more-btn-remote">
-                        <a href="${CWDocs.getDocLink(CWDocs.REMOTE_SETUP)}"><img class="learn-more-btn" alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a>
+                        <a href="${CWDocs.getDocLink(CWDocs.REMOTE_SETUP)}"><img class="learn-more-btn" alt="Learn More" src="${rp.getIcon(Resources.Icons.Help)}"/></a>
                     </div>
-                    ${isConnected ? `<img alt="Connected" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionConnectedCheckmark)}"/>` :
-                        `<img alt="Disconnected" src="${WebviewUtil.getIcon(Resources.Icons.ConnectionDisconnectedCheckmark)}"/>`
+                    ${isConnected ? `<img alt="Connected" src="${rp.getIcon(Resources.Icons.ConnectionConnectedCheckmark)}"/>` :
+                        `<img alt="Disconnected" src="${rp.getIcon(Resources.Icons.ConnectionDisconnectedCheckmark)}"/>`
                     }
                 </h3>
                 <div class="input">
                     <p ${connectionExists ? "style='display: none;'" : ""}>Fill in the fields about the connection that you're starting from.</p>
                     ${connectionExists ?
 `<label class="info-label" for="input-url">Codewind Gatekeeper URL</label>
-                        <img id="copy_url" onclick="copyURL(event)" alt="copy url" src="${WebviewUtil.getIcon(Resources.Icons.Copy)}"/><div id="copy_url_tooltip">Copied</div>`
+                        <img id="copy_url" onclick="copyURL(event)" alt="copy url" src="${rp.getIcon(Resources.Icons.Copy)}"/><div id="copy_url_tooltip">Copied</div>`
                         :
                         `<label class="info-label" for="input-url">Codewind Gatekeeper URL</label>`
                     }
@@ -87,13 +88,13 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
 
             <div>
                 <div id="link-container-box">
-                    <h3>Select Sources <a href="${CWDocs.getDocLink(CWDocs.TEMPLATE_MANAGEMENT)}"><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
+                    <h3>Select Sources <a href="${CWDocs.getDocLink(CWDocs.TEMPLATE_MANAGEMENT)}"><img alt="Learn More" src="${rp.getIcon(Resources.Icons.Help)}"/></a></h3>
                     <p>A source contains templates for creating cloud-native projects. Select the template sources that you want to use.</p><br>
                     <div type="button" class="btn btn-prominent" onclick=sendMsg("${ConnectionOverviewWVMessages.SOURCES}");>Open Template Source Manager</div>
                 </div>
 
                 <div id="link-container-box">
-                    <h3>Add Registries <a href="${CWDocs.getDocLink(CWDocs.REGISTRIES)}"><img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/></a></h3>
+                    <h3>Add Registries <a href="${CWDocs.getDocLink(CWDocs.REGISTRIES)}"><img alt="Learn More" src="${rp.getIcon(Resources.Icons.Help)}"/></a></h3>
                     <p class="registry-help-label">Optional: Add registries to pull private project images, or add a push registry for Codewind style projects.</p>
                     <div type="button" class="btn btn-prominent" onclick=sendMsg("${ConnectionOverviewWVMessages.REGISTRY}");>Open Container Registry Manager</div>
                 </div>
@@ -103,9 +104,9 @@ export default function getConnectionInfoHtml(connectionInfo: ConnectionOverview
 
             <div class="remote-connection-btn-group">
                 <div type="button" id="delete-btn" class="btn btn-prominent" onclick="deleteConnection()"
-                    ${connectionExists ? `style="display: inline-block;"` : `style="display: none;"`}>Remove Connection<img src="${WebviewUtil.getIcon(Resources.Icons.Delete)}"/></div>
+                    ${connectionExists ? `style="display: inline-block;"` : `style="display: none;"`}>Remove Connection<img src="${rp.getIcon(Resources.Icons.Delete)}"/></div>
                 <div type="button" id="edit-btn" class="btn btn-prominent" onclick="editConnection()"
-                    ${connectionExists ? `style="display: inline;"` : `style="display: none;"`}>Edit<img src="${WebviewUtil.getIcon(Resources.Icons.Edit_Connection)}"/></div>
+                    ${connectionExists ? `style="display: inline;"` : `style="display: none;"`}>Edit<img src="${rp.getIcon(Resources.Icons.Edit_Connection)}"/></div>
                 <div type="button" id="toggle-connect-btn" class="btn btn-prominent" onclick="toggleConnection()"
                     ${connectionExists ? `style="display: inline;"` : `style="display: none;"`}>${isConnected ? "Disconnect" : "Connect"}</div>
                 <div type="button" id="save-btn" class="btn btn-prominent" onclick="submitNewConnection()"

--- a/dev/src/command/webview/pages/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/pages/ProjectOverviewPage.ts
@@ -16,23 +16,8 @@ import MCUtil from "../../../MCUtil";
 import Project from "../../../codewind/project/Project";
 import WebviewUtil from "../WebviewUtil";
 import CWDocs from "../../../constants/CWDocs";
-
-// This file does have a bunch of strings that should be translated,
-// but the stringfinder is not smart enough to pick them out from the regular html strings. So, do this file by hand.
-// non-nls-file
-
-/**
- * These are the messages the WebView can send back to its creator in ProjectInfoCmd
- */
-export enum ProjectOverviewWVMessages {
-    BUILD = "build",
-    TOGGLE_AUTOBUILD = "toggleAutoBuild",
-    OPEN = "open",
-    UNBIND = "unbind",
-    TOGGLE_ENABLEMENT = "toggleEnablement",
-    EDIT = "edit",
-    TOGGLE_INJECT_METRICS = "toggleInjectMetrics",
-}
+import { ProjectOverviewWVMessages } from "../ProjectOverviewPageWrapper";
+import { WebviewResourceProvider } from "../WebviewWrapper";
 
 enum OpenableTypes {
     WEB = "web",
@@ -48,17 +33,11 @@ export interface IWVOpenable {
     value: string;
 }
 
-export function refreshProjectOverview(webviewPanel: vscode.WebviewPanel, project: Project): string {
-    const html = getProjectOverviewHtml(project);
-    webviewPanel.webview.html = html;
-    return html;
-}
-
 const NOT_AVAILABLE = "Not available";
 const NOT_RUNNING = "Not running";
 const NOT_DEBUGGING = "Not debugging";
 
-function getProjectOverviewHtml(project: Project): string {
+export function getProjectOverviewHtml(rp: WebviewResourceProvider, project: Project): string {
 
     // const emptyRow =
     // `
@@ -77,15 +56,15 @@ function getProjectOverviewHtml(project: Project): string {
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             ${WebviewUtil.getCSP()}
 
-            <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("common.css")}"/>
-            <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("project-overview.css")}"/>
+            <link rel="stylesheet" href="${rp.getStylesheet("common.css")}"/>
+            <link rel="stylesheet" href="${rp.getStylesheet("project-overview.css")}"/>
             ${global.isTheia ?
-                `<link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("theia.css")}"/>` : ""}
+                `<link rel="stylesheet" href="${rp.getStylesheet("theia.css")}"/>` : ""}
         </head>
         <body>
 
         <div class="title-section">
-            <img id="logo" alt="Codewind Logo" src="${WebviewUtil.getIcon(Resources.Icons.Logo)}"/>
+            <img id="logo" alt="Codewind Logo" src="${rp.getIcon(Resources.Icons.Logo)}"/>
             <h1>Project ${project.name}</h1>
         </div>
         <div id="top-section">
@@ -107,10 +86,10 @@ function getProjectOverviewHtml(project: Project): string {
         <div class="section">
             <h3>Project Information</h3>
             <table>
-                ${buildRow("Type", project.type.toString())}
-                ${buildRow("Language", MCUtil.uppercaseFirstChar(project.language))}
-                ${buildRow("Project ID", project.id)}
-                ${buildRow("Local Path", project.localPath.fsPath, global.isTheia ? undefined : OpenableTypes.FOLDER)}
+                ${buildRow(rp, "Type", project.type.toString())}
+                ${buildRow(rp, "Language", MCUtil.uppercaseFirstChar(project.language))}
+                ${buildRow(rp, "Project ID", project.id)}
+                ${buildRow(rp, "Local Path", project.localPath.fsPath, global.isTheia ? undefined : OpenableTypes.FOLDER)}
             </table>
         </div>
         <div class="section">
@@ -136,10 +115,10 @@ function getProjectOverviewHtml(project: Project): string {
                         />
                     </td>
                 </tr>
-                ${buildRow("Application Status", project.state.appState)}
-                ${buildRow("Build Status", normalize(project.state.getBuildString(), NOT_AVAILABLE))}
-                ${buildRow("Last Image Build", normalizeDate(project.lastImgBuild, NOT_AVAILABLE))}
-                ${buildRow("Last Build", normalizeDate(project.lastBuild, NOT_AVAILABLE))}
+                ${buildRow(rp, "Application Status", project.state.appState)}
+                ${buildRow(rp, "Build Status", normalize(project.state.getBuildString(), NOT_AVAILABLE))}
+                ${buildRow(rp, "Last Image Build", normalizeDate(project.lastImgBuild, NOT_AVAILABLE))}
+                ${buildRow(rp, "Last Build", normalizeDate(project.lastBuild, NOT_AVAILABLE))}
             </table>
         </div>
         <div class="section">
@@ -152,21 +131,21 @@ function getProjectOverviewHtml(project: Project): string {
             <!-- Hide Container ID in theia -->
             ${global.isTheia ? "" : `
                 <table class="bottom-padded">
-                    ${buildRow("Container ID", normalize(project.containerID, NOT_AVAILABLE, 32))}
+                    ${buildRow(rp, "Container ID", normalize(project.containerID, NOT_AVAILABLE, 32))}
                 </table>`
             }
 
             <table>
-                ${buildRow("Application Endpoint",
+                ${buildRow(rp, "Application Endpoint",
                     normalize(project.appUrl, NOT_RUNNING),
                     (project.appUrl != null ? OpenableTypes.WEB : undefined), true)}
-                ${buildRow("Exposed App Port", normalize(project.ports.appPort, NOT_RUNNING))}
-                ${buildRow("Internal App Port",
+                ${buildRow(rp, "Exposed App Port", normalize(project.ports.appPort, NOT_RUNNING))}
+                ${buildRow(rp, "Internal App Port",
                     normalize(project.ports.internalPort, NOT_AVAILABLE),
                     undefined, true)}
 
                 <!-- buildDebugSection must also close the <table> -->
-                ${buildDebugSection(project)}
+                ${buildDebugSection(rp, project)}
             <!-- /table -->
         </div>
 
@@ -188,7 +167,7 @@ function getProjectOverviewHtml(project: Project): string {
     `;
 }
 
-function buildRow(label: string, data: string, openable?: OpenableTypes, editable: boolean = false): string {
+function buildRow(rp: WebviewResourceProvider, label: string, data: string, openable?: OpenableTypes, editable: boolean = false): string {
     let secondColTdContents: string = "";
     let thirdColTdContents: string = "";
     if (openable) {
@@ -204,7 +183,7 @@ function buildRow(label: string, data: string, openable?: OpenableTypes, editabl
 
         thirdColTdContents = `
             <input type="image" id="edit-${MCUtil.slug(label)}" class="edit-btn" ${tooltip} ${onClick}` +
-                `src="${WebviewUtil.getIcon(Resources.Icons.Edit)}"/>
+                `src="${rp.getIcon(Resources.Icons.Edit)}"/>
         `;
     }
 
@@ -213,7 +192,7 @@ function buildRow(label: string, data: string, openable?: OpenableTypes, editabl
     const fourthTd = openable === OpenableTypes.WEB ?
         `
         <td>
-            <input type="image" title="Open" src="${WebviewUtil.getIcon(Resources.Icons.OpenExternal)}" onclick="vscOpen('${openable}', '${data}')"/>
+            <input type="image" title="Open" src="${rp.getIcon(Resources.Icons.OpenExternal)}" onclick="vscOpen('${openable}', '${data}')"/>
         </td>
         `
         : "";
@@ -264,7 +243,7 @@ function normalizeDate(d: Date, fallback: string): string {
     }
 }
 
-function buildDebugSection(project: Project): string {
+function buildDebugSection(rp: WebviewResourceProvider, project: Project): string {
     if (global.isTheia) {
         return `
             </table>
@@ -287,11 +266,11 @@ function buildDebugSection(project: Project): string {
     }
 
     return `
-        ${buildRow("Exposed Debug Port", normalize(project.ports.debugPort, NOT_DEBUGGING))}
-        ${buildRow("Internal Debug Port",
+        ${buildRow(rp, "Exposed Debug Port", normalize(project.ports.debugPort, NOT_DEBUGGING))}
+        ${buildRow(rp, "Internal Debug Port",
             normalize(project.ports.internalDebugPort, NOT_AVAILABLE),
             undefined, true)}
         </table>
     `;
-        // ${buildRow("Debug URL", normalize(project.debugUrl, NOT_DEBUGGING))}
+        // ${buildRow(rp, "Debug URL", normalize(project.debugUrl, NOT_DEBUGGING))}
 }

--- a/dev/src/command/webview/pages/RegistriesPage.ts
+++ b/dev/src/command/webview/pages/RegistriesPage.ts
@@ -17,10 +17,16 @@ import Resources from "../../../constants/Resources";
 import WebviewUtil from "../WebviewUtil";
 import { ManageRegistriesWVMessages } from "../RegistriesPageWrapper";
 import { ContainerRegistry } from "../../../codewind/connection/RegistryUtils";
+import { WebviewResourceProvider } from "../WebviewWrapper";
 
 const FULL_ADDRESS_ATTR = "data-full-address";
 
-export default function getManageRegistriesPage(connectionLabel: string, registries: ContainerRegistry[], needsPushRegistry: boolean): string {
+export default function getManageRegistriesPage(
+    rp: WebviewResourceProvider,
+    connectionLabel: string,
+    registries: ContainerRegistry[],
+    needsPushRegistry: boolean): string {
+
     return `
     <!DOCTYPE html>
 
@@ -30,38 +36,38 @@ export default function getManageRegistriesPage(connectionLabel: string, registr
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         ${WebviewUtil.getCSP()}
 
-        <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("sources-registries-tables.css")}"/>
-        <link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("common.css")}"/>
+        <link rel="stylesheet" href="${rp.getStylesheet("sources-registries-tables.css")}"/>
+        <link rel="stylesheet" href="${rp.getStylesheet("common.css")}"/>
         ${global.isTheia ?
-            `<link rel="stylesheet" href="${WebviewUtil.getStylesheetPath("theia.css")}"/>` : ""}
+            `<link rel="stylesheet" href="${rp.getStylesheet("theia.css")}"/>` : ""}
     </head>
     <body>
 
     <div id="top-section">
         <div class="title-section ${global.isTheia ? "" : "title-section-subtitled"}">
-            <img id="logo" alt="Codewind Logo" src="${WebviewUtil.getIcon(Resources.Icons.Logo)}"/>
+            <img id="logo" alt="Codewind Logo" src="${rp.getIcon(Resources.Icons.Logo)}"/>
             <div>
                 <h1 id="title">Image Registries</h1>
                 ${global.isTheia ? "" : `<h2 id="subtitle">${connectionLabel}</h2>`}
             </div>
         </div>
         <div tabindex="0" id="learn-more-btn" class="btn" onclick="sendMsg('${ManageRegistriesWVMessages.HELP}')">
-            Learn More<img alt="Learn More" src="${WebviewUtil.getIcon(Resources.Icons.Help)}"/>
+            Learn More<img alt="Learn More" src="${rp.getIcon(Resources.Icons.Help)}"/>
         </div>
     </div>
 
     <div id="toolbar">
         <div id="toolbar-right-buttons">
             <div tabindex="0" class="btn btn-background" onclick="sendMsg('${ManageRegistriesWVMessages.REFRESH}')">
-                Refresh<img alt="Refresh" src="${WebviewUtil.getIcon(Resources.Icons.Refresh)}"/>
+                Refresh<img alt="Refresh" src="${rp.getIcon(Resources.Icons.Refresh)}"/>
             </div>
             <div tabindex="0" id="add-btn" class="btn btn-prominent" onclick="addNew()">
-                Add New<img alt="Add New" src="${WebviewUtil.getIcon(Resources.Icons.New)}"/>
+                Add New<img alt="Add New" src="${rp.getIcon(Resources.Icons.New)}"/>
             </div>
         </div>
     </div>
 
-    ${buildTable(registries, needsPushRegistry)}
+    ${buildTable(rp, registries, needsPushRegistry)}
 
     <script>
         const vscode = acquireVsCodeApi();
@@ -102,7 +108,7 @@ export default function getManageRegistriesPage(connectionLabel: string, registr
     `;
 }
 
-function buildTable(registries: ContainerRegistry[], needsPushRegistry: boolean): string {
+function buildTable(rp: WebviewResourceProvider, registries: ContainerRegistry[], needsPushRegistry: boolean): string {
 
     if (registries.length === 0) {
         return `
@@ -113,7 +119,7 @@ function buildTable(registries: ContainerRegistry[], needsPushRegistry: boolean)
         `;
     }
 
-    const rows = registries.map((registry) => buildRow(registry, needsPushRegistry));
+    const rows = registries.map((registry) => buildRow(rp, registry, needsPushRegistry));
 
     return `
     <table>
@@ -144,7 +150,7 @@ function buildTable(registries: ContainerRegistry[], needsPushRegistry: boolean)
     `;
 }
 
-function buildRow(registry: ContainerRegistry, needsPushRegistry: boolean): string {
+function buildRow(rp: WebviewResourceProvider, registry: ContainerRegistry, needsPushRegistry: boolean): string {
     // These two columns are left out for the local non-che connection, which does not use a push registry.
     let namespaceTD = "";
     let pushRegistryTD = "";
@@ -173,12 +179,12 @@ function buildRow(registry: ContainerRegistry, needsPushRegistry: boolean): stri
         ${pushRegistryTD}
         <!--td class="btn-cell">
             <input type="image" ${FULL_ADDRESS_ATTR}="${registry.fullAddress}" alt="Edit ${registry.fullAddress}" title="Edit"
-                onclick="" class="btn" src="${WebviewUtil.getIcon(Resources.Icons.Edit)}"
+                onclick="" class="btn" src="${rp.getIcon(Resources.Icons.Edit)}"
             />
         </td-->
         <td class="btn-cell">
             <input type="image" ${FULL_ADDRESS_ATTR}="${registry.fullAddress}" alt="Delete ${registry.fullAddress}" title="Delete ${registry.fullAddress}"
-                onclick="deleteRegistry(this)" class="btn" src="${WebviewUtil.getIcon(Resources.Icons.Trash)}"
+                onclick="deleteRegistry(this)" class="btn" src="${rp.getIcon(Resources.Icons.Trash)}"
             />
         </td>
     </tr>

--- a/dev/src/view/TreeItemFactory.ts
+++ b/dev/src/view/TreeItemFactory.ts
@@ -152,7 +152,7 @@ namespace TreeItemFactory {
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             tooltip: label,
             contextValue: TreeItemContext.getProjectContext(project),
-            iconPath: project.type.icon,
+            iconPath: Resources.getIconPaths(project.type.icon),
             // command run on single-click (or double click - depends on a user setting - https://github.com/Microsoft/vscode/issues/39601)
             command,
         };


### PR DESCRIPTION
- Extension version to 0.8
- Required VS Code version to 1.38
- Refactor webviews
    - Remove webview boilerplate by using a superclass
    - Refactor Project Overview to have a wrapper like other webviews
    - Use webview.asWebviewUri to get resource URIs
        - Fixes https://github.com/eclipse/codewind/issues/1442