### PR TITLE
Improvements to Registries page

### DIFF
--- a/dev/src/codewind/connection/CLICommandRunner.ts
+++ b/dev/src/codewind/connection/CLICommandRunner.ts
@@ -12,7 +12,7 @@
 import CLIWrapper from "./CLIWrapper";
 import Log from "../../Logger";
 import MCUtil from "../../MCUtil";
-import { ITemplateSource } from "../../command/webview/SourcesPageWrapper";
+import { TemplateSource } from "./TemplateSourceList";
 
 export interface CLIConnectionData {
     readonly id: string;
@@ -192,6 +192,8 @@ export namespace CLICommandRunner {
         ]);
     }
 
+    ///// Connection management commands
+
     /**
      * @returns The data for the new Connection
      */
@@ -223,8 +225,9 @@ export namespace CLICommandRunner {
         await CLIWrapper.cliExec(ConnectionCommands.REMOVE, [ "--conid", id ]);
     }
 
-    // https://github.com/eclipse/codewind/issues/941
-    export async function addTemplateSource(connectionID: string, url: string, name: string, descr?: string): Promise<ITemplateSource[]> {
+    ///// Template source management commands - These should only be used by the TemplateSourceList
+
+    export async function addTemplateSource(connectionID: string, url: string, name: string, descr?: string): Promise<TemplateSource[]> {
         const args = [
             "--conid", connectionID,
             "--url", url,
@@ -238,25 +241,22 @@ export namespace CLICommandRunner {
         return CLIWrapper.cliExec(TemplateRepoCommands.ADD, args);
     }
 
-    let hasFetchedTemplates = false;
-    export async function getTemplateSources(connectionID: string): Promise<ITemplateSource[]> {
-        // The first time we fetch template sources per-codewind instance can be very slow, so we show a progress notification just once
-        const progress = hasFetchedTemplates ? undefined : "Fetching template sources...";
+    export async function getTemplateSources(connectionID: string, showProgress: boolean): Promise<TemplateSource[]> {
+        const progress = showProgress ? undefined : "Fetching template sources...";
 
-        const result = await CLIWrapper.cliExec(TemplateRepoCommands.LIST, [
+        return CLIWrapper.cliExec(TemplateRepoCommands.LIST, [
             "--conid", connectionID,
         ], progress);
-
-        hasFetchedTemplates = true;
-        return result;
     }
 
-    export async function removeTemplateSource(connectionID: string, url: string): Promise<ITemplateSource[]> {
+    export async function removeTemplateSource(connectionID: string, url: string): Promise<TemplateSource[]> {
         return CLIWrapper.cliExec(TemplateRepoCommands.REMOVE, [
             "--conid", connectionID,
             "--url", url
         ]);
     }
+
+    ///// Auth/credential commands
 
     export async function updateKeyringCredentials(connectionID: string, username: string, password: string): Promise<void> {
         // in the success case, the output is just an OK status

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -24,9 +24,9 @@ import LocalCodewindManager from "./local/LocalCodewindManager";
 import CodewindEventListener, { OnChangeCallbackArgs } from "./CodewindEventListener";
 import CLIWrapper from "./CLIWrapper";
 import { ConnectionStates, ConnectionState } from "./ConnectionState";
-import { CLICommandRunner } from "./CLICommandRunner";
-import { SourcesPageWrapper, ITemplateSource } from "../../command/webview/SourcesPageWrapper";
+import { SourcesPageWrapper } from "../../command/webview/SourcesPageWrapper";
 import { RegistriesPageWrapper } from "../../command/webview/RegistriesPageWrapper";
+import TemplateSourcesList from "./TemplateSourceList";
 
 export const LOCAL_CONNECTION_ID = "local";
 
@@ -44,6 +44,8 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
 
     private _projects: Project[] = [];
     private needProjectUpdate: boolean = true;
+
+    public readonly templateSourcesList: TemplateSourcesList = new TemplateSourcesList(this);
 
     private _sourcesPage: SourcesPageWrapper  | undefined;
     private _registriesPage: RegistriesPageWrapper | undefined;
@@ -383,6 +385,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         await this.forceUpdateProjectList(true);
     }
 
+    // QuickPick detail
     public get detail(): string {
         return this.url.toString();
     }
@@ -391,9 +394,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         return this._socket ? this._socket.uri : undefined;
     }
 
-    public getSources(): Promise<ITemplateSource[]> {
-        return CLICommandRunner.getTemplateSources(this.id);
-    }
+    ///// Webview management
 
     public onDidOpenSourcesPage(page: SourcesPageWrapper): void {
         this._sourcesPage = page;

--- a/dev/src/codewind/connection/TemplateSourceList.ts
+++ b/dev/src/codewind/connection/TemplateSourceList.ts
@@ -1,0 +1,69 @@
+import Connection from "./Connection";
+import { CLICommandRunner } from "./CLICommandRunner";
+import { ISourceEnablement } from "../../command/webview/SourcesPageWrapper";
+import Requester from "../project/Requester";
+
+const CODEWIND_PROJECT_STYLE = "Codewind";
+
+/**
+ * Template repository/source data as provided by the backend
+ */
+export interface TemplateSource {
+    readonly url: string;
+    readonly name?: string;
+    readonly description?: string;
+    readonly enabled: boolean;
+    readonly projectStyles: string[];
+    readonly protected: boolean;
+}
+
+export default class TemplateSourcesList {
+
+    private templateSources: TemplateSource[] | undefined;
+
+    private hasInitialized: boolean = false;
+
+    constructor(
+        public readonly connection: Connection,
+    ) {
+
+    }
+
+    public toString(): string {
+        if (this.templateSources == null) {
+            return `Uninitialized TemplateSourcesList`;
+        }
+        return this.templateSources.toString();
+    }
+
+    public async get(refresh: boolean = false): Promise<TemplateSource[]> {
+        if (this.templateSources == null || refresh) {
+            this.templateSources = await CLICommandRunner.getTemplateSources(this.connection.id, this.hasInitialized);
+            this.hasInitialized = true;
+        }
+        return this.templateSources;
+    }
+
+    public async add(url: string, name: string, description: string | undefined): Promise<TemplateSource[]> {
+        this.templateSources = await CLICommandRunner.addTemplateSource(this.connection.id, url, name, description);
+        return this.templateSources;
+    }
+
+    public async remove(url: string): Promise<TemplateSource[]> {
+        this.templateSources = await CLICommandRunner.removeTemplateSource(this.connection.id, url);
+        return this.templateSources;
+    }
+
+    public async toggleEnablement(enablement: ISourceEnablement): Promise<TemplateSource[]> {
+        await Requester.toggleSourceEnablement(this.connection, enablement);
+        return this.get(true);
+    }
+
+    // for https://github.com/eclipse/codewind/issues/1469
+    public async hasCodewindSourceEnabled(): Promise<boolean> {
+        const templateSources = this.templateSources || await this.get();
+        return templateSources
+            .filter((source) => source.enabled)
+            .some((source) => source.projectStyles.includes(CODEWIND_PROJECT_STYLE));
+    }
+}

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -74,7 +74,11 @@ namespace Requester {
         value: string;
     }
 
-    export async function enableTemplateRepos(connection: Connection, enablements: ISourceEnablement): Promise<void> {
+    /**
+     * Change the 'enabled' state of the given set of template sources.
+     * Should only be called by TemplateSourceList to ensure it is refreshed appropriately.
+     */
+    export async function toggleSourceEnablement(connection: Connection, enablements: ISourceEnablement): Promise<void> {
         const body: IRepoEnablementReq[] = enablements.repos.map((repo) => {
             return {
                 op: "enable",

--- a/dev/src/command/webview/WebviewWrapper.ts
+++ b/dev/src/command/webview/WebviewWrapper.ts
@@ -89,7 +89,7 @@ export abstract class WebviewWrapper {
             newHtml = await this.generateHtml(this.resourceProvider);
         }
         catch (err) {
-            const errMsg = `Error with wizard page ${this.title}:`;
+            const errMsg = `${this.title} error:`;
             Log.e(errMsg, err);
             vscode.window.showErrorMessage(`${errMsg} ${MCUtil.errToString(err)}`);
             return;

--- a/dev/src/command/webview/pages/SourcesPage.ts
+++ b/dev/src/command/webview/pages/SourcesPage.ts
@@ -14,14 +14,15 @@
 import Resources from "../../../constants/Resources";
 // import MCUtil from "../../MCUtil";
 import WebviewUtil, { CommonWVMessages } from "../WebviewUtil";
-import { ITemplateSource, ManageSourcesWVMessages } from "../SourcesPageWrapper";
+import { ManageSourcesWVMessages } from "../SourcesPageWrapper";
 import { WebviewResourceProvider } from "../WebviewWrapper";
+import { TemplateSource } from "../../../codewind/connection/TemplateSourceList";
 
 const SOURCE_ID_ATTR = "data-id";
 const SOURCE_ENABLED_ATTR = "data-enabled";
 
 export default function getManageSourcesPage(
-    rp: WebviewResourceProvider, connectionLabel: string, isRemoteConnection: boolean, sources: ITemplateSource[]): string {
+    rp: WebviewResourceProvider, connectionLabel: string, isRemoteConnection: boolean, sources: TemplateSource[]): string {
 
     return `
     <!DOCTYPE html>
@@ -120,7 +121,7 @@ export default function getManageSourcesPage(
     `;
 }
 
-function buildTemplateTable(rp: WebviewResourceProvider, sources: ITemplateSource[]): string {
+function buildTemplateTable(rp: WebviewResourceProvider, sources: TemplateSource[]): string {
 
     const repoRows = sources.map((source) => buildRow(rp, source));
 
@@ -149,7 +150,7 @@ function buildTemplateTable(rp: WebviewResourceProvider, sources: ITemplateSourc
     `;
 }
 
-function buildRow(rp: WebviewResourceProvider, source: ITemplateSource): string {
+function buildRow(rp: WebviewResourceProvider, source: TemplateSource): string {
     const name = source.name || "No name available";
     const descr = source.description || "No description available";
     return `
@@ -163,7 +164,7 @@ function buildRow(rp: WebviewResourceProvider, source: ITemplateSource): string 
     `;
 }
 
-function getStatusToggleTD(rp: WebviewResourceProvider, source: ITemplateSource): string {
+function getStatusToggleTD(rp: WebviewResourceProvider, source: TemplateSource): string {
     return `<td class="btn-cell">
         <input type="image" alt="${getStatusToggleAlt(source.enabled)}" ${SOURCE_ID_ATTR}="${source.url}" ${SOURCE_ENABLED_ATTR}="${source.enabled}"
             class="source-toggle btn" src="${getStatusToggleIconSrc(rp, source.enabled)}" onclick="onToggleSource(this)"/>
@@ -184,7 +185,7 @@ function getStatusToggleIconSrc(rp: WebviewResourceProvider, enabled: boolean, e
     return toggleIcon;
 }
 
-function getDeleteBtnTD(rp: WebviewResourceProvider, source: ITemplateSource): string {
+function getDeleteBtnTD(rp: WebviewResourceProvider, source: TemplateSource): string {
     let title = "Delete";
     let deleteBtnClass = "btn";
     let onClick = "deleteRepo(this)";


### PR DESCRIPTION
- Cache template sources per-connection
    - Can now access template sources from Registries page
    - Fixes https://github.com/eclipse/codewind/issues/1469
- Cancel registry addition if namespace step is exited
    - https://github.com/eclipse/codewind/issues/1621
- Add warning that namespace is lost when switching push registries
    - Fixes https://github.com/eclipse/codewind/issues/1421

Signed-off-by: Tim Etchells <timetchells@ibm.com>