### PR TITLE
Remove storing connections in extension data

### DIFF
--- a/dev/src/codewind/connection/CLICommands.ts
+++ b/dev/src/codewind/connection/CLICommands.ts
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+export interface CLICommandOptions {
+    cancellable?: boolean;
+    hasJSONOutput?: boolean;
+    censorOutput?: boolean;
+}
+
+export class CLICommand {
+
+    public readonly cancellable: boolean = false;
+    public readonly hasJSONOutput: boolean = true;
+    public readonly censorOutput: boolean = false;
+
+    constructor(
+        public readonly command: string[],
+        options?: CLICommandOptions,
+    ) {
+        if (options) {
+            if (options.cancellable != null) {
+                this.cancellable = options.cancellable;
+            }
+            if (options.hasJSONOutput != null) {
+                this.hasJSONOutput = options.hasJSONOutput;
+            }
+            if (options.censorOutput != null) {
+                this.censorOutput = options.censorOutput;
+            }
+        }
+    }
+}
+
+export namespace CLICommands {
+    export const STATUS = new CLICommand([ "status" ]);
+    export const UPGRADE = new CLICommand([ "upgrade" ]);
+
+    // command 'families'
+    const PROJECT_CMD = "project";
+    const CONNECTIONS_CMD = "connections";
+    const TEMPLATES_CMD = "templates";
+    // we call them 'sources' cwctl calls them 'repos'
+    const SOURCES_CMD = "repos";
+
+    export const PROJECT = {
+        CREATE: new CLICommand([ PROJECT_CMD, "create" ]),
+        SYNC:   new CLICommand([ PROJECT_CMD, "sync" ]),
+        BIND:   new CLICommand([ PROJECT_CMD, "bind" ]),
+        MANAGE_CONN: new CLICommand([ PROJECT_CMD, "connection" ]),
+    };
+
+    export const CONNECTIONS = {
+        ADD:    new CLICommand([ CONNECTIONS_CMD, "add" ]),
+        LIST:   new CLICommand([ CONNECTIONS_CMD, "list" ]),
+        REMOVE: new CLICommand([ CONNECTIONS_CMD, "remove" ]),
+        UPDATE: new CLICommand([ CONNECTIONS_CMD, "update" ], { hasJSONOutput: false })
+    };
+
+    export const TEMPLATE_SOURCES = {
+        ADD:    new CLICommand([ TEMPLATES_CMD, SOURCES_CMD, "add" ]),
+        LIST:   new CLICommand([ TEMPLATES_CMD, SOURCES_CMD, "list" ]),
+        REMOVE: new CLICommand([ TEMPLATES_CMD, SOURCES_CMD, "remove" ]),
+    };
+
+    export const AUTHENTICATION = {
+        KEYRING_UPDATE: new CLICommand([ "seckeyring", "update" ]),
+        // KEYRING_VALIDATE: new CLICommand([ "seckeyring", "validate" ]),
+        GET_SECTOKEN: new CLICommand([ "sectoken", "get" ], { censorOutput: true }),
+    };
+}

--- a/dev/src/codewind/connection/CLIWrapper.ts
+++ b/dev/src/codewind/connection/CLIWrapper.ts
@@ -19,8 +19,8 @@ import MCUtil from "../../MCUtil";
 import Log from "../../Logger";
 import { CLILifecycleWrapper } from "./local/CLILifecycleWrapper";
 import { CLILifecycleCommand } from "./local/CLILifecycleCommands";
-import { CLICommand } from "./CLICommandRunner";
 import Constants from "../../constants/Constants";
+import { CLICommand } from "./CLICommands";
 
 const BIN_DIR = "bin";
 const CLI_EXECUTABLE = "cwctl";

--- a/dev/src/codewind/connection/ConnectionManager.ts
+++ b/dev/src/codewind/connection/ConnectionManager.ts
@@ -17,7 +17,7 @@ import Project from "../project/Project";
 import CodewindEventListener from "./CodewindEventListener";
 import MCUtil from "../../MCUtil";
 import RemoteConnection from "./RemoteConnection";
-import { CLICommandRunner } from "./CLICommandRunner";
+import { CLICommandRunner, CLIConnectionData } from "./CLICommandRunner";
 import { ConnectionMemento } from "./ConnectionMemento";
 
 export default class ConnectionManager implements vscode.Disposable {
@@ -75,13 +75,14 @@ export default class ConnectionManager implements vscode.Disposable {
         const newConnID = await ConnectionMemento.addConnection(label, ingressUrl, username);
         await CLICommandRunner.updateKeyringCredentials(newConnID, username, password);
 
-        const newMemento: ConnectionMemento = {
+        const newData: CLIConnectionData = {
             id: newConnID,
-            ingressUrl: ingressUrl.toString(),
+            url: ingressUrl.toString(),
             label: label,
             username: username,
         };
-        const newConnection = new RemoteConnection(ingressUrl, newMemento);
+
+        const newConnection = new RemoteConnection(ingressUrl, newData);
         await this.onNewConnection(newConnection);
         return newConnection;
     }
@@ -89,11 +90,11 @@ export default class ConnectionManager implements vscode.Disposable {
     /**
      * Set up a remote connection that was loaded from `cwctl connections`
      */
-    public async loadRemoteConnection(memento: ConnectionMemento): Promise<RemoteConnection> {
-        Log.i("Recreating connection to " + memento.ingressUrl);
+    public async loadRemoteConnection(connectionData: CLIConnectionData): Promise<RemoteConnection> {
+        Log.i("Recreating connection to " + connectionData.url);
 
-        const ingressUrl = vscode.Uri.parse(memento.ingressUrl);
-        const loadedConnection = new RemoteConnection(ingressUrl, memento);
+        const ingressUrl = vscode.Uri.parse(connectionData.url);
+        const loadedConnection = new RemoteConnection(ingressUrl, connectionData);
         await this.onNewConnection(loadedConnection);
         return loadedConnection;
     }

--- a/dev/src/codewind/connection/RemoteConnection.ts
+++ b/dev/src/codewind/connection/RemoteConnection.ts
@@ -14,11 +14,11 @@ import * as vscode from "vscode";
 import Connection from "./Connection";
 import ConnectionOverviewWrapper from "../../command/webview/ConnectionOverviewPageWrapper";
 import { ConnectionStates, ConnectionState } from "./ConnectionState";
-import { CLICommandRunner, AccessToken } from "./CLICommandRunner";
+import { CLICommandRunner, AccessToken, CLIConnectionData } from "./CLICommandRunner";
 import Log from "../../Logger";
-import { ConnectionMemento } from "./ConnectionMemento";
 import { CreateFileWatcher, FileWatcher } from "codewind-filewatcher";
 import { FWAuthToken } from "codewind-filewatcher/lib/FWAuthToken";
+import { ConnectionMemento } from "./ConnectionMemento";
 
 export default class RemoteConnection extends Connection {
 
@@ -37,11 +37,10 @@ export default class RemoteConnection extends Connection {
 
     constructor(
         ingressUrl: vscode.Uri,
-        memento: ConnectionMemento
+        cliData: CLIConnectionData,
     ) {
-        super(memento.id, ingressUrl, memento.label, true);
-        this._username = memento.username;
-        ConnectionMemento.save(memento);
+        super(cliData.id, ingressUrl, cliData.label, true);
+        this._username = cliData.username;
     }
 
     public async enable(): Promise<void> {
@@ -162,7 +161,7 @@ export default class RemoteConnection extends Connection {
         Log.i(`Start updateCredentials for ${this}`);
 
         this._username = username;
-        await ConnectionMemento.save(this.memento);
+        await ConnectionMemento.save(this.cliData);
 
         // Just in case there are multiple quick credentials updates
         await this.updateCredentialsPromise;
@@ -217,11 +216,11 @@ export default class RemoteConnection extends Connection {
         return this._username;
     }
 
-    public get memento(): ConnectionMemento {
+    public get cliData(): CLIConnectionData {
         return {
             id: this.id,
             label: this.label,
-            ingressUrl: this.url.toString(),
+            url: this.url.toString(),
             username: this._username,
         };
     }

--- a/dev/src/codewind/connection/local/CLILifecycleCommands.ts
+++ b/dev/src/codewind/connection/local/CLILifecycleCommands.ts
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 import { CodewindStates } from "./CodewindStates";
-import { CLICommand } from "../CLICommandRunner";
+import { CLICommand } from "../CLICommands";
 
 const TAG_PLACEHOLDER = `$tag$`;
 

--- a/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
@@ -42,7 +42,7 @@ export enum ConnectionOverviewWVMessages {
  * The editable textfields in the Connection (left half) part of the overview
  */
 interface ConnectionInfoFields {
-    readonly ingressUrl?: string;
+    readonly url?: string;
     readonly username?: string;
     readonly password?: string;
 }
@@ -66,7 +66,7 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
             connection.overviewPage.reveal();
             return connection.overviewPage;
         }
-        return new ConnectionOverviewWrapper(connection.memento, connection);
+        return new ConnectionOverviewWrapper(connection.cliData, connection);
     }
 
     /////
@@ -86,7 +86,7 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
         if (this.connection) {
             isConnnected = this.connection.isConnected;
         }
-        const connectionInfo = this.connection ? this.connection.memento : { label: this.label };
+        const connectionInfo = this.connection ? this.connection.cliData : { label: this.label };
         return getConnectionInfoHtml(resourceProvider, connectionInfo, isConnnected);
     }
 
@@ -132,7 +132,7 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
                         }
                         catch (err) {
                             // the err from createNewConnection is user-friendly
-                            Log.w(`Error creating new connection to ${newInfo.ingressUrl}`, err);
+                            Log.w(`Error creating new connection to ${newInfo.url}`, err);
                             vscode.window.showErrorMessage(`${MCUtil.errToString(err)}`);
                         }
                     }
@@ -200,12 +200,12 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
      * Returns the new Connection if it succeeds. Returns undefined if user cancels. Throws errors.
      */
     private async createNewConnection(newConnectionInfo: ConnectionInfoFields, label: string): Promise<RemoteConnection> {
-        if (!newConnectionInfo.ingressUrl) {
+        if (!newConnectionInfo.url) {
             throw new Error("Enter a Codewind Gatekeeper ingress host");
         }
-        Log.d("Ingress host is", newConnectionInfo.ingressUrl);
+        Log.d("Ingress host is", newConnectionInfo.url);
 
-        let ingressUrlStr = newConnectionInfo.ingressUrl.trim();
+        let ingressUrlStr = newConnectionInfo.url.trim();
         try {
             if (!ingressUrlStr.includes("://")) {
                 Log.d(`No protocol; assuming https`);

--- a/dev/src/command/webview/pages/ConnectionOverviewPage.ts
+++ b/dev/src/command/webview/pages/ConnectionOverviewPage.ts
@@ -19,7 +19,7 @@ import { WebviewResourceProvider } from "../WebviewWrapper";
 
 export default function getConnectionInfoHtml(rp: WebviewResourceProvider, connectionInfo: ConnectionOverviewFields, isConnected: boolean): string {
     // If the ingress URL has been saved, then we have created the connection and we are now viewing or editing it.
-    const connectionExists = !!connectionInfo.ingressUrl;
+    const connectionExists = !!connectionInfo.url;
     return `
     <!DOCTYPE html>
     <html>
@@ -62,14 +62,14 @@ export default function getConnectionInfoHtml(rp: WebviewResourceProvider, conne
                     ${connectionExists ? `
                         <label class="info-label" for="input-url">Codewind Gatekeeper URL</label>
                         <input type="image" id="copy_url" onclick="copyURL(event)" alt="Copy URL" src="${rp.getIcon(Resources.Icons.Copy)}"/>
-                        <div id="copy_url_tooltip">Copied</div>`
+                        <div id="copy_url_tooltip">Copied!</div>`
                         :
                         `<label class="info-label" for="input-url">Codewind Gatekeeper URL</label>`
                     }
-                    <div id="url" ${connectionExists ? "" : "style='display: none;'"}>${connectionInfo.ingressUrl}</div>
+                    <div id="url" ${connectionExists ? "" : "style='display: none;'"}>${connectionInfo.url}</div>
                     <input type="text" id="ingress-url" class="input-url" name="ingress-url" placeholder="codewind-gatekeeper-mycluster.nip.io"
                         ${connectionExists ? "style='display: none;'" : ""}
-                        value="${connectionInfo.ingressUrl ? connectionInfo.ingressUrl : ""}"/>
+                        value="${connectionInfo.url ? connectionInfo.url : ""}"/>
 
                     <div style="float: left; margin-top: 2em">
                         <label class="info-label" for="input-username">Username</label>
@@ -146,7 +146,7 @@ export default function getConnectionInfoHtml(rp: WebviewResourceProvider, conne
             }
 
             // If none of the fields changed, treat it the same as a cancel
-            if (ingressInput === '${connectionInfo.ingressUrl}'
+            if (ingressInput === '${connectionInfo.url}'
                 && ingressUsername === '${connectionInfo.username}'
                 && !ingressPassword) {
 
@@ -154,7 +154,7 @@ export default function getConnectionInfoHtml(rp: WebviewResourceProvider, conne
             } else {
                 // Data body is IConnectionInfoFields
                 sendMsg("${ConnectionOverviewWVMessages.SAVE_CONNECTION_INFO}", {
-                    ingressUrl: ingressInput,
+                    url: ingressInput,
                     username: ingressUsername,
                     password: ingressPassword,
                     label: connectionName
@@ -198,7 +198,7 @@ export default function getConnectionInfoHtml(rp: WebviewResourceProvider, conne
             let copiedURLToolTip = document.getElementById('copy_url_tooltip');
             copiedURLToolTip.style.display = "inline";
             copiedURLToolTip.style.position = "absolute";
-            copiedURLToolTip.style.left = e.pageX + 15 + 'px';
+            copiedURLToolTip.style.left = e.pageX + 25 + 'px';
             copiedURLToolTip.style.top = e.pageY - 10 +'px';
 
             setTimeout(function(){ copiedURLToolTip.style.display = "none"; }, 1000);


### PR DESCRIPTION
- No longer required since cwctl saves username and codewind saves registry data
- Fixes https://github.com/eclipse/codewind/issues/1641
- Separate CLI Command enumerations from CLICommandRunner
- Move 'copied' tooltip a little to the right to not overlap the icon

Signed-off-by: Tim Etchells <timetchells@ibm.com>