### PR TITLE
1452 - Use --path when calling cwctl project create

### DIFF
--- a/dev/src/codewind/connection/CLICommandRunner.ts
+++ b/dev/src/codewind/connection/CLICommandRunner.ts
@@ -77,16 +77,15 @@ export namespace CLICommandRunner {
     /**
      * Test the path given to determine the project type Codewind should use.
      */
-    export async function detectProjectType(connectionID: string, projectPath: string, desiredType?: string): Promise<IInitializationResponse> {
+    export async function detectProjectType(projectPath: string, desiredType?: string): Promise<IInitializationResponse> {
         const args = [
-            projectPath,
-            "--conid", connectionID,
+            "--path", projectPath,
         ];
 
         if (desiredType) {
             args.push("--type", desiredType);
         }
-        return CLIWrapper.cliExec(CLICommands.PROJECT.CREATE, args, `Processing ${projectPath}...`);
+        return CLIWrapper.cliExec(CLICommands.PROJECT.VALIDATE, args, `Processing ${projectPath}...`);
     }
 
     /**

--- a/dev/src/codewind/connection/CLICommandRunner.ts
+++ b/dev/src/codewind/connection/CLICommandRunner.ts
@@ -65,12 +65,11 @@ export namespace CLICommandRunner {
         return statusObj;
     }
 
-    export async function createProject(connectionID: string, projectPath: string, url: string)
+    export async function createProject(projectPath: string, url: string)
         : Promise<IInitializationResponse> {
 
         return CLIWrapper.cliExec(CLICommands.PROJECT.CREATE, [
-            projectPath,
-            "--conid", connectionID,
+            "--path", projectPath,
             "--url", url
         ]);
     }

--- a/dev/src/codewind/connection/CLICommands.ts
+++ b/dev/src/codewind/connection/CLICommands.ts
@@ -53,6 +53,7 @@ export namespace CLICommands {
     export const PROJECT = {
         CREATE: new CLICommand([ PROJECT_CMD, "create" ]),
         SYNC:   new CLICommand([ PROJECT_CMD, "sync" ]),
+        VALIDATE: new CLICommand([PROJECT_CMD, "validate"]),
         BIND:   new CLICommand([ PROJECT_CMD, "bind" ]),
         MANAGE_CONN: new CLICommand([ PROJECT_CMD, "connection" ]),
     };

--- a/dev/src/command/connection/BindProjectCmd.ts
+++ b/dev/src/command/connection/BindProjectCmd.ts
@@ -51,7 +51,7 @@ async function detectAndBind(connection: Connection, pathToBindUri: vscode.Uri):
     Log.i("Binding to", pathToBind);
 
     const projectName = path.basename(pathToBind);
-    const validateRes = await detectProjectType(connection, pathToBind);
+    const validateRes = await detectProjectType(pathToBind);
     if (validateRes.status !== SocketEvents.STATUS_SUCCESS) {
         // failed
         const failedResult = (validateRes.result as { error: string });
@@ -99,7 +99,7 @@ async function detectAndBind(connection: Connection, pathToBindUri: vscode.Uri):
     // validate once more with detected type and subtype (if defined),
     // to run any extension defined command involving subtype
     if (projectTypeInfo.projectSubtype) {
-        await detectProjectType(connection, pathToBind, projectTypeInfo.projectType + ":" + projectTypeInfo.projectSubtype);
+        await detectProjectType(pathToBind, projectTypeInfo.projectType + ":" + projectTypeInfo.projectSubtype);
     }
 
     await addProjectToConnection(connection, projectName, pathToBind, projectTypeInfo);
@@ -258,8 +258,8 @@ async function promptForLanguageOrSubtype(choices: IProjectSubtypesDescriptor): 
     return language.id;
 }
 
-async function detectProjectType(connection: Connection, pathToBind: string, desiredType?: string): Promise<IInitializationResponse> {
-    return CLICommandRunner.detectProjectType(connection.id, pathToBind, desiredType);
+async function detectProjectType(pathToBind: string, desiredType?: string): Promise<IInitializationResponse> {
+    return CLICommandRunner.detectProjectType(pathToBind, desiredType);
     // Log.d("Detection response", detectResponse);
     // return detectResponse;
 }

--- a/dev/src/command/connection/CreateUserProjectCmd.ts
+++ b/dev/src/command/connection/CreateUserProjectCmd.ts
@@ -415,8 +415,7 @@ export async function createProject(connection: Connection, template: CWTemplate
         location: vscode.ProgressLocation.Notification,
         title: `Creating ${projectName}...`
     }, async () => {
-        const creationRes = await CLICommandRunner.createProject(connection.id, projectPath, template.url);
-
+        const creationRes = await CLICommandRunner.createProject(projectPath, template.url);
         if (creationRes.status !== SocketEvents.STATUS_SUCCESS) {
             // failed
             let failedReason = `Unknown error creating ${projectName} at ${projectPath}`;


### PR DESCRIPTION
Changes to accompany https://github.com/eclipse/codewind-installer/pull/317 which makes the following changes to the `cwctl project create` command:

- Use `--path`, rather than the first non-flagged argument, as the destination filepath. 

- Splits out the operations on a dir already on disk into a different subcommand to. Currently, this is done by not giving a URL when calling create. This is `cwctl project validate` here, but I think there was confusion about using this before, so happy to discuss and change (or revert to 1 single command, but I think the no URL, if the dir is already there, trick is odd). 

Also, removes `conid` from the arguments of the calls to both commands, as these are both exclusive to a users filesystem and therefore don't need one.