### PR TITLE
Use current image tag for cwctl copy-out dir

### DIFF
--- a/dev/src/codewind/connection/CLIWrapper.ts
+++ b/dev/src/codewind/connection/CLIWrapper.ts
@@ -65,7 +65,8 @@ namespace CLIWrapper {
         const cwctlBasename = path.basename(cwctlSourcePath);
 
         const dotCodewindPath = path.join(os.homedir(), Constants.DOT_CODEWIND_DIR);
-        const binaryTargetDir = path.join(dotCodewindPath, global.extVersion);
+        const codewindVersion = CLILifecycleWrapper.DEFAULT_CW_TAG;
+        const binaryTargetDir = path.join(dotCodewindPath, codewindVersion);
 
         // fails on windows, see note about electron https://github.com/nodejs/node/issues/24698#issuecomment-486405542
         // await promisify(fs.mkdir)(binaryTargetDir, { recursive: true });

--- a/dev/src/codewind/connection/local/CLILifecycleWrapper.ts
+++ b/dev/src/codewind/connection/local/CLILifecycleWrapper.ts
@@ -32,12 +32,17 @@ const STRING_NS = StringNamespaces.STARTUP;
 
 const TAG_OPTION = "-t";
 
-const TAG_LATEST = "latest";
-// Codewind tag to install if CW_TAG is not set in env
-// UPDATE THIS on release branches to eg "0.6.0"
-const DEFAULT_CW_TAG = TAG_LATEST;
-
 export namespace CLILifecycleWrapper {
+
+    /**
+     * Used only in development.
+     */
+    export const TAG_LATEST = "latest";
+    /**
+     * Codewind tag to install if CW_TAG is not set in env
+     * UPDATE THIS on release branches to eg "0.6.0"
+     */
+    export const DEFAULT_CW_TAG = TAG_LATEST;
 
     // serves as a lock, only one operation at a time.
     let currentOperation: CLILifecycleCommand | undefined;


### PR DESCRIPTION
So for development, it's 'latest' instead of the current release.
Fixes https://github.com/eclipse/codewind/issues/1748

Signed-off-by: Tim Etchells <timetchells@ibm.com>