### PR TITLE
open correct application monitor when project language is javascript

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -41,6 +41,7 @@ import ProjectOverviewPageWrapper from "../../command/webview/ProjectOverviewPag
 const langToPathMap = new Map<string, string>();
 langToPathMap.set("java", "javametrics-dash");
 langToPathMap.set("nodejs", "appmetrics-dash");
+langToPathMap.set("javascript", "appmetrics-dash");
 langToPathMap.set("swift", "swiftmetrics-dash");
 
 const STRING_NS = StringNamespaces.PROJECT;


### PR DESCRIPTION
Part of https://github.com/eclipse/codewind/issues/784. 

Opens the correct application monitor URL when `language=javascript`.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>