### PR TITLE
Improve extension startup behaviour in cheia

### DIFF
--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -99,7 +99,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     protected async enable(): Promise<void> {
         Log.i(`${this.label} starting base enable`);
 
-        const readyTimeoutS = 60;
+        const readyTimeoutS = 90;
         const ready = await Requester.waitForReady(this, readyTimeoutS);
         if (!ready) {
             throw new Error(`${this.label} connected, but was not ready after ${readyTimeoutS} seconds. Try reconnecting to, or restarting, this Codewind instance.`);
@@ -111,8 +111,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         // which does the initial projects population and sets the state to Connected
         this._socket = new MCSocket(this, envData.socketNamespace);
 
-        const initFWProm = this.initFileWatcher();
-        await initFWProm;
+        await this.initFileWatcher();
 
         try {
             Log.d("Updating projects list after ready");

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -152,7 +152,7 @@ export default class LocalCodewindManager {
 
         // This looks awfully similar to Requester.waitForReady, but here we're just testing for a listening port.
         const timeoutS = 180;
-        const delayS = 2;
+        const delayS = 5;
         const maxTries = timeoutS / delayS;
         const longerThanUsualTries = Math.round(maxTries / 2);
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1783
Lengthens timeouts and treats 502 as a ping failure
Connection now stays in 'starting' state longer and shouldn't timeout waiting for ready

Signed-off-by: Tim Etchells <timetchells@ibm.com>