### PR TITLE
Update

### DIFF
--- a/dev/src/codewind/connection/CLICommandRunner.ts
+++ b/dev/src/codewind/connection/CLICommandRunner.ts
@@ -65,10 +65,11 @@ export namespace CLICommandRunner {
         return statusObj;
     }
 
-    export async function createProject(projectPath: string, url: string)
+    export async function createProject(connectionID: string, projectPath: string, url: string)
         : Promise<IInitializationResponse> {
 
         return CLIWrapper.cliExec(CLICommands.PROJECT.CREATE, [
+            "--conid", connectionID,
             "--path", projectPath,
             "--url", url
         ]);
@@ -77,8 +78,9 @@ export namespace CLICommandRunner {
     /**
      * Test the path given to determine the project type Codewind should use.
      */
-    export async function detectProjectType(projectPath: string, desiredType?: string): Promise<IInitializationResponse> {
+    export async function detectProjectType(connectionID: string, projectPath: string, desiredType?: string): Promise<IInitializationResponse> {
         const args = [
+            "--conid", connectionID,
             "--path", projectPath,
         ];
 

--- a/dev/src/codewind/connection/RegistryUtils.ts
+++ b/dev/src/codewind/connection/RegistryUtils.ts
@@ -269,7 +269,7 @@ namespace RegistryUtils {
 
         Log.d(`Setting push registry to ${newPushRegistry.address}`);
 
-        if (!namespace) {
+        if (namespace == null) {
             namespace = await promptForNamespace(newPushRegistry.address, newPushRegistry.username);
             if (namespace == null) {
                 return undefined;

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -206,27 +206,32 @@ export default class Project implements vscode.QuickPickItem {
             this.appBaseURL = asUri;
         }
 
-        const oldCapabilitiesReady = this._capabilitiesReady;
-        this._capabilitiesReady = projectInfo.capabilitiesReady;
-        if (oldCapabilitiesReady !== this._capabilitiesReady) {
-            // Log.d(`${this.name} capabilities now ready`);
-            this.updateCapabilities();
-        }
-
         const wasEnabled = this.state.isEnabled;
         const oldStateStr = this.state.toString();
         const stateChanged = this.state.update(projectInfo);
 
+        let wasDisabled = false;
         if (stateChanged) {
             const startModeMsg = projectInfo.startMode == null ? "" : `, startMode=${projectInfo.startMode}`;
             Log.d(`${this.name} went from ${oldStateStr} to ${this._state}${startModeMsg}`);
 
             // Check if the project was just enabled or disabled
             if (wasEnabled && !this.state.isEnabled) {
+                wasDisabled = true;
                 this.onDisable();
             }
             else if (!wasEnabled && this.state.isEnabled) {
                 this.onEnable();
+            }
+        }
+
+        const oldCapabilitiesReady = this._capabilitiesReady;
+        this._capabilitiesReady = projectInfo.capabilitiesReady;
+        if (oldCapabilitiesReady !== this._capabilitiesReady) {
+            // Retain the capabilities for a project that was disabled.
+            if (!wasDisabled) {
+                // Log.d(`${this.name} capabilities now ready`);
+                this.updateCapabilities();
             }
         }
 
@@ -385,24 +390,18 @@ export default class Project implements vscode.QuickPickItem {
     }
 
     private async updateCapabilities(): Promise<void> {
-        let capabilities: ProjectCapabilities;
         if (!this.state.isEnabled || !this._capabilitiesReady) {
             // The project must refresh the capabilities on re-enable, or when capabilitiesReady becomes true.
             // server will return a 404 in this case
-            capabilities = ProjectCapabilities.NO_CAPABILITIES;
+            return;
         }
-        else {
-            try {
-                capabilities = await Requester.getCapabilities(this);
-            }
-            catch (err) {
-                // If the project is enabled and there is an error, we fall back to all capabilities so as not to block any UI actions.
-                // But this should never happen
-                Log.e("Error retrieving capabilities for " + this.name, err);
-                capabilities = ProjectCapabilities.NO_CAPABILITIES;
-            }
+        try {
+            this._capabilities = await Requester.getCapabilities(this);
         }
-        this._capabilities = capabilities;
+        catch (err) {
+            Log.e("Error retrieving capabilities for " + this.name, err);
+            this._capabilities = ProjectCapabilities.NO_CAPABILITIES;
+        }
         this.onChange();
     }
 
@@ -443,6 +442,14 @@ export default class Project implements vscode.QuickPickItem {
         }
         // this.logManager.destroyAllLogs();
         this.logManager?.destroyAllLogs();
+
+        // Clear now-invalid application info
+        this._containerID = undefined;
+        this.appBaseURL = undefined;
+        this.updatePorts({
+            exposedPort: undefined,
+            exposedDebugPort: undefined,
+        });
     }
 
     public async dispose(): Promise<void> {
@@ -558,11 +565,7 @@ export default class Project implements vscode.QuickPickItem {
         return this._state;
     }
 
-    public get capabilities(): ProjectCapabilities {
-        // This will only happen if this funciton is called before the initPromise resolves, which should never happen
-        if (!this._capabilities) {
-            this._capabilities = ProjectCapabilities.ALL_CAPABILITIES;
-        }
+    public get capabilities(): ProjectCapabilities | undefined {
         return this._capabilities;
     }
 
@@ -705,10 +708,10 @@ export default class Project implements vscode.QuickPickItem {
 
         const changed = this._containerID !== oldContainerID;
         if (changed) {
-            const asStr: string = this._containerID == null ? "undefined" : this._containerID.substring(0, 8);
-            if (asStr.length === 0) {
-                Log.w(`Empty containerID for ${this.name}`);
+            if (this._containerID === "") {
+                this._containerID = undefined;
             }
+            const asStr = this._containerID == null ? "undefined" : this._containerID.substring(0, 8);
             Log.d(`New containerID for ${this.name} is ${asStr}`);
         }
         return changed;

--- a/dev/src/codewind/project/ProjectState.ts
+++ b/dev/src/codewind/project/ProjectState.ts
@@ -99,7 +99,7 @@ export class ProjectState {
         if (this.appState === ProjectState.AppStates.UNKNOWN) {
             if (!buildStatusStr) {
                 // Log.w(`${this.projectName} has unknown app and build statuses`);
-                return "";
+                return "[Unknown]";
             }
             // Return only the build status if app status is unknown
             return `[${buildStatusStr}]`;

--- a/dev/src/command/connection/BindProjectCmd.ts
+++ b/dev/src/command/connection/BindProjectCmd.ts
@@ -51,7 +51,7 @@ async function detectAndBind(connection: Connection, pathToBindUri: vscode.Uri):
     Log.i("Binding to", pathToBind);
 
     const projectName = path.basename(pathToBind);
-    const validateRes = await detectProjectType(pathToBind);
+    const validateRes = await detectProjectType(connection, pathToBind);
     if (validateRes.status !== SocketEvents.STATUS_SUCCESS) {
         // failed
         const failedResult = (validateRes.result as { error: string });
@@ -99,7 +99,7 @@ async function detectAndBind(connection: Connection, pathToBindUri: vscode.Uri):
     // validate once more with detected type and subtype (if defined),
     // to run any extension defined command involving subtype
     if (projectTypeInfo.projectSubtype) {
-        await detectProjectType(pathToBind, projectTypeInfo.projectType + ":" + projectTypeInfo.projectSubtype);
+        await detectProjectType(connection, pathToBind, projectTypeInfo.projectType + ":" + projectTypeInfo.projectSubtype);
     }
 
     await addProjectToConnection(connection, projectName, pathToBind, projectTypeInfo);
@@ -258,8 +258,8 @@ async function promptForLanguageOrSubtype(choices: IProjectSubtypesDescriptor): 
     return language.id;
 }
 
-async function detectProjectType(pathToBind: string, desiredType?: string): Promise<IInitializationResponse> {
-    return CLICommandRunner.detectProjectType(pathToBind, desiredType);
+async function detectProjectType(connection: Connection, pathToBind: string, desiredType?: string): Promise<IInitializationResponse> {
+    return CLICommandRunner.detectProjectType(connection.id, pathToBind, desiredType);
     // Log.d("Detection response", detectResponse);
     // return detectResponse;
 }

--- a/dev/src/command/connection/CreateUserProjectCmd.ts
+++ b/dev/src/command/connection/CreateUserProjectCmd.ts
@@ -416,7 +416,7 @@ export async function createProject(connection: Connection, template: CWTemplate
         location: vscode.ProgressLocation.Notification,
         title: `Creating ${projectName}...`
     }, async () => {
-        const creationRes = await CLICommandRunner.createProject(projectPath, template.url);
+        const creationRes = await CLICommandRunner.createProject(connection.id, projectPath, template.url);
         if (creationRes.status !== SocketEvents.STATUS_SUCCESS) {
             // failed
             let failedReason = `Unknown error creating ${projectName} at ${projectPath}`;

--- a/dev/src/command/webview/pages/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/pages/ProjectOverviewPage.ts
@@ -261,7 +261,7 @@ function buildDebugSection(rp: WebviewResourceProvider, project: Project): strin
     if (project.connection.isRemote) {
         noDebugMsg = "Remote projects do not support debug.";
     }
-    else if (!project.capabilities.supportsDebug) {
+    else if (project.capabilities && project.capabilities.supportsDebug) {
         noDebugMsg = `${project.type} projects do not support debug.`;
     }
 

--- a/dev/src/test/project/Removal.test.ts
+++ b/dev/src/test/project/Removal.test.ts
@@ -19,13 +19,13 @@ import { testProjects } from "./Creation.test";
 
 describe(`Project removal wrapper`, function() {
 
+    before(`should use the precreated test projects`, function() {
+        expect(testProjects, `No test projects were found`).to.exist.and.have.length.greaterThan(0);
+    });
+
     // We nest the dynamically generated tests in a before() so they don't execute too soon
     // https://stackoverflow.com/a/54681623
     before(async function() {
-        before(`should use the precreated test projects`, function() {
-            expect(testProjects, `No test projects were found`).to.exist.and.have.length.greaterThan(0);
-        });
-
         describe(`Project removal`, function() {
             testProjects.forEach((project) => {
 

--- a/dev/src/test/project/Restart.test.ts
+++ b/dev/src/test/project/Restart.test.ts
@@ -34,7 +34,11 @@ describe(`Restart tests wrapper`, async function() {
 
             testProjects.forEach((project) => {
 
-                if (!project.capabilities.supportsRestart) {
+                it(`${project.name} should have capabilities`, async function() {
+                    expect(project.capabilities).to.exist;
+                });
+
+                if (!project.capabilities?.supportsRestart) {
                     // skip these tests for this project
                     return;
                 }

--- a/dev/src/view/TreeItemContext.ts
+++ b/dev/src/view/TreeItemContext.ts
@@ -136,7 +136,7 @@ namespace TreeItemContext {
             contextValues.push(TreeItemContextValues.PROJ_AUTOBUILD_OFF);
         }
 
-        if (project.capabilities.supportsRestart) {
+        if (project.capabilities?.supportsRestart) {
             contextValues.push(TreeItemContextValues.PROJ_RESTARTABLE);
         }
 


### PR DESCRIPTION
- Improve overview behaviour for disabled projects
    - Also fixes misleading "project does not support debug" for disabled projects which do support debug, when enabled.
- Fix double namespace prompt when empty
- Check test projects before removal tests
- Add connection ID back to cwctl create & validate