### PR TITLE
Create a debug config for debuggable project types when projects are initialised

### DIFF
--- a/dev/src/codewind/project/DebugUtils.ts
+++ b/dev/src/codewind/project/DebugUtils.ts
@@ -169,7 +169,7 @@ export default class DebugUtils {
      *
      * @return The new debug configuration which can then be passed to startDebugging
      */
-    private static async setDebugConfig(project: Project): Promise<vscode.DebugConfiguration> {
+    public static async setDebugConfig(project: Project): Promise<vscode.DebugConfiguration> {
         const debugName: string = DebugUtils.getDebugName(project);
 
         let launchToWrite: vscode.DebugConfiguration | undefined;

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -159,7 +159,8 @@ export default class Project implements vscode.QuickPickItem {
         // The function calling the constructor must await on this promise before expecting the project to be ready.
         this.initPromise = Promise.all([
             this.updateCapabilities(),
-            this.updateMetricsAvailable()
+            this.updateMetricsAvailable(),
+            this.updateDebugConfig(),
         ])
         .then(() => Promise.resolve());
 
@@ -404,6 +405,17 @@ export default class Project implements vscode.QuickPickItem {
         }
         this._capabilities = capabilities;
         this.onChange();
+    }
+
+    private async updateDebugConfig(): Promise<void> {
+        try {
+            if (this.type.debugType !== undefined) {
+                DebugUtils.setDebugConfig(this);
+            }
+        }
+        catch (err) {
+            Log.e(`Error creating debug configuration for  ${this.name}`, err);
+        }
     }
 
     private async updateMetricsAvailable(): Promise<void> {


### PR DESCRIPTION
This PR follows on from a change to the profiling LSP: https://github.com/eclipse/codewind-node-profiler/pull/12

That change uses the debug configuration for a project to map the source paths between the container and the source code in the project. (Essentially the debugger and the profiler have the same problem - the source isn't in the same place in the local workspace as it is when run in the container.)

The codewind vscode plugin was generating this information when debug mode was enabled, this change causes it to be generated when the project is opened initially which makes sure it is available if you run a performance run without debugging first.

This is for issue: https://github.com/eclipse/codewind/issues/533