### PR TITLE
Fix logic error when showing 'no debug' message

### DIFF
--- a/dev/src/command/webview/pages/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/pages/ProjectOverviewPage.ts
@@ -261,8 +261,13 @@ function buildDebugSection(rp: WebviewResourceProvider, project: Project): strin
     if (project.connection.isRemote) {
         noDebugMsg = "Remote projects do not support debug.";
     }
-    else if (project.capabilities && project.capabilities.supportsDebug) {
-        noDebugMsg = `${project.type} projects do not support debug.`;
+    else if (project.capabilities && !project.capabilities.supportsDebug) {
+        if (project.type.isExtensionType) {
+            noDebugMsg = `This project does not support debug.`;
+        }
+        else {
+            noDebugMsg = `${project.type} projects do not support debug.`;
+        }
     }
 
     if (noDebugMsg) {


### PR DESCRIPTION
Also exclude project type because it was confusing for Appsody projects

Signed-off-by: Tim Etchells <timetchells@ibm.com>