### PR TITLE
Save Profiling Data to Local Workspace

### DIFF
--- a/dev/src/codewind/connection/MCSocket.ts
+++ b/dev/src/codewind/connection/MCSocket.ts
@@ -92,6 +92,7 @@ export default class MCSocket implements vscode.Disposable {
 
             .on(SocketEvents.Types.PROJECT_VALIDATED,       this.onProjectValidated)
             .on(SocketEvents.Types.PROJECT_SETTING_CHANGED, this.onProjectSettingsChanged)
+            .on(SocketEvents.Types.LOAD_RUNNER,             this.onLoadRunnerStatusChanged)
             .on(SocketEvents.Types.LOG_UPDATE,              this.onLogUpdate)
             .on(SocketEvents.Types.LOGS_LIST_CHANGED,       this.onLogsListChanged)
             .on(SocketEvents.Types.REGISTRY_STATUS,         this.onPushRegistryStatus)
@@ -246,6 +247,20 @@ export default class MCSocket implements vscode.Disposable {
         }
         // Log.d("projectSettingsChanged", payload);
         return project.onSettingsChangedEvent(payload);
+    }
+
+    private readonly onLoadRunnerStatusChanged = async (payload: {projectID: string, status: string, timestamp: string}):
+        Promise<void> => {
+        const project = await this.getProject(payload);
+        if (project == null) {
+            return;
+        }
+        try {
+            await project.onLoadRunnerUpdate(payload);
+        } catch (error) {
+            Log.e("Error retrieving profiling data from pfe", error);
+            vscode.window.showErrorMessage(`Error retrieving profiling data from pfe for ${project.name}`);
+        }
     }
 
     private readonly onPushRegistryStatus = async (payload: SocketEvents.IPushRegistryStatus): Promise<void> => {

--- a/dev/src/codewind/connection/SocketEvents.ts
+++ b/dev/src/codewind/connection/SocketEvents.ts
@@ -96,6 +96,7 @@ namespace SocketEvents {
         PROJECT_DELETION = "projectDeletion",
         PROJECT_RESTART_RESULT = "projectRestartResult",
         PROJECT_SETTING_CHANGED = "projectSettingsChanged",
+        LOAD_RUNNER = "runloadStatusChanged",
         LOG_UPDATE = "log-update",
         LOGS_LIST_CHANGED = "projectLogsListChanged",
         PROJECT_VALIDATED = "projectValidated",

--- a/dev/src/constants/Endpoints.ts
+++ b/dev/src/constants/Endpoints.ts
@@ -41,6 +41,7 @@ export enum ProjectEndpoints {
     LOGS = "logs",
     METRICS_STATUS = "metrics/status",
     METRICS_INJECTION = "metrics/inject",
+    PROFILING = "profiling",
 
     OPEN = "open",
     CLOSE = "close",


### PR DESCRIPTION
To work with changes [here](https://github.com/eclipse/codewind/pull/1891).

- Adds a new listener to socket events from loadRunner
- Upon load runner successfully copying health center data from project pod to PFE, this data is then copied from PFE down to the local workspace of the project to enable to Java profiler to function
- Upon load runner saving profiling.json to PFE, the file is retrieved from the profiling API and saved into the local workspace to enable to Node profiler to function

This currently only works with a local PFE.

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>