### PR TITLE
Enable metrics injection for Docker Java projects

### DIFF
--- a/dev/src/codewind/project/ProjectType.ts
+++ b/dev/src/codewind/project/ProjectType.ts
@@ -127,7 +127,11 @@ export class ProjectType {
             ProjectType.InternalTypes.MICROPROFILE,
             ProjectType.InternalTypes.NODE,
             ProjectType.InternalTypes.SPRING
-        ].includes(this.internalType);
+        ].includes(this.internalType) ||
+            ([ProjectType.InternalTypes.DOCKER].includes(this.internalType) &&
+            [ProjectType.Languages.JAVA].map((lang) => lang.toString().toLowerCase())
+            .includes(this.language.toLowerCase())
+        );
     }
 
     public get alwaysHasAppMonitor(): boolean {

--- a/dev/src/codewind/project/ProjectType.ts
+++ b/dev/src/codewind/project/ProjectType.ts
@@ -128,9 +128,8 @@ export class ProjectType {
             ProjectType.InternalTypes.NODE,
             ProjectType.InternalTypes.SPRING
         ].includes(this.internalType) ||
-            ([ProjectType.InternalTypes.DOCKER].includes(this.internalType) &&
-            [ProjectType.Languages.JAVA].map((lang) => lang.toString().toLowerCase())
-            .includes(this.language.toLowerCase())
+            (this.internalType === ProjectType.InternalTypes.DOCKER && 
+                this.language.toLowerCase() === ProjectType.Languages.JAVA
         );
     }
 


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR fixes the front end for https://github.com/eclipse/codewind/issues/1509 in VSCode

OpenLiberty projects are currently defined as type Docker with language Java. I've raised https://github.com/eclipse/codewind/issues/1960 to try and improve that.

Please feel free to comment on anything I've missed!