### PR TITLE
Remote Profiling

### DIFF
--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -505,7 +505,7 @@ export default class Project implements vscode.QuickPickItem {
         const endpoint = ProjectEndpoints.PROFILING.toString().concat(`/${event.timestamp}`);
         const url = EndpointUtil.resolveProjectEndpoint(this.connection, this.id, endpoint as ProjectEndpoints);
         try {
-            await Requester.httpWriteStreamToFile(url, profilingOutPath);
+            await Requester.getProfilingData(this, url, profilingOutPath);
         } catch (error) {
             Log.e(`Error receiving profiling data from pfe for ${this.name}`, error);
             vscode.window.showErrorMessage(`Error receiving profiling data for ${this.name}`);

--- a/dev/src/codewind/project/Requester.ts
+++ b/dev/src/codewind/project/Requester.ts
@@ -377,20 +377,36 @@ namespace Requester {
         await project.setInjectMetrics(newInjectMetrics);
     }
 
-    export async function httpWriteStreamToFile(url: string, filePath: string): Promise<void> {
-        return new Promise((resolve, reject) => {
-            let protocol;
-            if (!url.startsWith("http")) {
-                protocol = https;
-            } else {
-                protocol = http;
+    export async function getProfilingData(project: Project, url: string, filePath: string): Promise<void> {
+        let protocol;
+        let options;
+        if (project.connection instanceof RemoteConnection) {
+            if (!url.startsWith("https")) {
+                throw new Error(`Refusing to send access token to non-secure URL ${url}`);
             }
-            const wStream = fs.createWriteStream(filePath);
-            const newRequest = protocol.request(url, (res) => {
-                res.on("error", (err) => {
+            const accessToken = await project.connection.getAccessToken();
+            options = {
+                agent: new https.Agent({rejectUnauthorized: false}),
+                headers: {
+                    Authorization: ` Bearer ${accessToken.access_token}`
+                }
+            } as https.RequestOptions;
+            protocol = https;
+        } else {
+            protocol = http;
+        }
+        const wStream = fs.createWriteStream(filePath);
+        return await httpWriteStreamToFile(url, options, protocol, wStream);
+    }
+
+    async function httpWriteStreamToFile(url: string, options: https.RequestOptions | undefined, protocol: any,
+                                         wStream: fs.WriteStream): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const newRequest = protocol.request(url, options, (res: any) => {
+                res.on("error", (err: any) => {
                     return reject(err);
                 });
-                res.on("data", (data) => {
+                res.on("data", (data: any) => {
                     wStream.write(data);
                 });
                 res.on("end", () => {
@@ -399,7 +415,7 @@ namespace Requester {
                 res.on("aborted", () => {
                     return reject();
                 });
-            }).on("error", (err) => {
+            }).on("error", (err: any) => {
                 return reject(err);
             });
             newRequest.end();


### PR DESCRIPTION
- getProfilingData wrapper for httpWriteStreamToFile function that sets protocol/https auth header

Enables the retrieval of profiling data from remote projects.

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>