### PR TITLE
Separate 'is Theia' from 'is Che'

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -22,7 +22,7 @@
         - You can also `export CW_TAG=0.6.0` in the terminal, before launching VS Code from that same terminal. This works even outside of Extension Development mode.
 - You can build the extension `.vsix` yourself by running [`vsce package`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions) from `dev/`. Refer to the [`Jenkinsfile`](https://github.com/eclipse/codewind-vscode/blob/master/Jenkinsfile) to see the exact steps the build runs.
 - The extension bundles dependency executables. These are gitignored, but should be kept up-to-date on your local system with the same versions used in the `Jenkinsfile` `parameters` section. Run `dev/bin/pull.sh` to download the dependencies. Also see `dev/bin/README.txt`.
-- The [`prebuild`](https://github.com/eclipse/codewind-vscode/blob/master/dev/prebuild.js) script is used in the CI builds to build separate versions of the extension for VS Code and Theia, since each of those has some commands that the other does not. It deletes inapplicable commands from the `package.json`, and does not modify any ts/js code. Run this before `vsce package` to get a closer-to-production build, but be ready to revert the changes.
+- The [`prebuild`](https://github.com/eclipse/codewind-vscode/blob/master/dev/prebuild.js) script is used in the CI builds to build separate versions of the extension for VS Code and Che, since some commands do not apply to Che. It deletes inapplicable commands from the `package.json`, and does not modify any ts/js code. Run this before `vsce package` to get a closer-to-production build, but be ready to revert the changes.
 
 ## Building Codewind from the source
 1. Clone the [`codewind`](https://github.com/eclipse/codewind) repository.

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-if [[ $1 == "theia" ]]; then
-    is_theia="true"
+if [[ $1 == "che" ]]; then
+    is_che="true"
 fi
 
 set -ex
 
 cd $(dirname $0)/../dev
 
-if [[ $is_theia ]]; then
-    echo "Building for Theia"
-    ./prebuild.js theia
+if [[ $is_che ]]; then
+    echo "Building for Che"
+    ./prebuild.js che
 else
     echo "Building for VS Code"
     ./prebuild.js vscode
@@ -28,8 +28,8 @@ npx vsce package
 artifact_name=$(basename *.vsix)
 # name is the part before first hyphen eg "codewind"
 new_name="${artifact_name%-*}"
-if [[ $is_theia ]]; then
-    new_name="${new_name}-theia"
+if [[ $is_che ]]; then
+    new_name="${new_name}-che"
 fi
 # artifact name without extension
 artifact_basename="${artifact_name%.*}"

--- a/dev/prebuild.js
+++ b/dev/prebuild.js
@@ -16,7 +16,7 @@ const fs = require("fs");
 const util = require("util");
 const { exec } = require("child_process");
 
-const theia_cmdsToDelete = [
+const che_cmdsToDelete = [
     "startCodewind",
     "startCodewind2",
     "stopCodewind",
@@ -79,7 +79,7 @@ function removeMenus(menus, cmdsToDelete) {
     return menus;
 }
 
-async function prebuildTheia(pj) {
+async function prebuildChe(pj) {
 
     // Contribute a viewcontainer instead of to the explorer view
     pj.contributes.viewsContainers = {
@@ -101,8 +101,8 @@ async function prebuildTheia(pj) {
     };
 
     // Delete unwanted commands and their respective menu entries
-    pj.contributes.commands = removeCommands(pj.contributes.commands, theia_cmdsToDelete);
-    pj.contributes.menus = removeMenus(pj.contributes.menus, theia_cmdsToDelete);
+    pj.contributes.commands = removeCommands(pj.contributes.commands, che_cmdsToDelete);
+    pj.contributes.menus = removeMenus(pj.contributes.menus, che_cmdsToDelete);
 
     // Delete the binaries that aren't needed.
     const BIN_DIR = "bin";
@@ -128,15 +128,15 @@ async function prebuildVSCode(pj) {
 async function main() {
 
     const prebuildType = process.argv[2];
-    let isForTheia;
-    if (prebuildType === "theia") {
-        isForTheia = true;
+    let isForChe;
+    if (prebuildType === "che") {
+        isForChe = true;
     }
     else if (prebuildType === "vscode") {
-        isForTheia = false;
+        isForChe = false;
     }
     else {
-        throw new Error(`This script must be called with either "theia" or "vscode" as argv[2]. ` +
+        throw new Error(`This script must be called with either "che" or "vscode" as argv[2]. ` +
             `Received "${prebuildType}"`);
     }
 
@@ -144,8 +144,8 @@ async function main() {
 
     let pj = JSON.parse(await util.promisify(fs.readFile)(PACKAGE_JSON_PATH));
 
-    if (isForTheia) {
-        pj = await prebuildTheia(pj);
+    if (isForChe) {
+        pj = await prebuildChe(pj);
     }
     else {
         pj = await prebuildVSCode(pj);

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -176,8 +176,8 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     }
 
     private async initFileWatcher(): Promise<void> {
-        if (global.isTheia) {
-            Log.i("In theia; no filewatcher required");
+        if (global.isChe) {
+            Log.i("In Che; no filewatcher required");
             return;
         }
 
@@ -195,8 +195,8 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     }
 
     private getPFEHost(): string {
-        if (global.isTheia) {
-            // On theia we have to use the che ingress
+        if (global.isChe) {
+            // On Che we have to use the che ingress
             // something like CHE_API_EXTERNAL=http://che-eclipse-che.9.28.239.191.nip.io/api
             const cheExternalUrlStr = process.env[Constants.CHE_API_EXTERNAL_ENVVAR];
             Log.d(`${Constants.CHE_API_EXTERNAL_ENVVAR}=${cheExternalUrlStr}`);
@@ -354,7 +354,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
      * This is the case for remote connections, or the local connection in theia.
      */
     public get isKubeConnection(): boolean {
-        return this.isRemote || global.isTheia;
+        return this.isRemote || global.isChe;
     }
 
     public async needsPushRegistry(): Promise<boolean> {
@@ -425,11 +425,11 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
     }
 
     public get pfeBaseURL(): vscode.Uri {
-        if (!global.isTheia) {
+        if (!global.isChe) {
             return this.url;
         }
 
-        // In theia, we have to use the environment to figure out the Codewind ingress (in place of using a kube client)
+        // In Che, we have to use the environment to figure out the Codewind ingress (in place of using a kube client)
         if (this.codewindCheIngress) {
             return this.codewindCheIngress;
         }

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -205,7 +205,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
                 const cheExternalUrl = vscode.Uri.parse(cheExternalUrlStr);
                 const authority = cheExternalUrl.authority;
                 if (authority) {
-                    Log.i("Setting connection host in Theia to " + authority);
+                    Log.i("Setting connection host in Che to " + authority);
                     return authority;
                 }
             }
@@ -351,7 +351,7 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
 
     /**
      * Returns if this connection's CW instance is running in Kube.
-     * This is the case for remote connections, or the local connection in theia.
+     * This is the case for remote connections, or the local connection in che.
      */
     public get isKubeConnection(): boolean {
         return this.isRemote || global.isChe;

--- a/dev/src/codewind/connection/ConnectionManager.ts
+++ b/dev/src/codewind/connection/ConnectionManager.ts
@@ -107,7 +107,7 @@ export default class ConnectionManager implements vscode.Disposable {
         }
         Log.i("Creating connection to " + url);
 
-        const label = global.isTheia ? "Codewind in Che" : "Local Codewind";
+        const label = global.isChe ? "Codewind in Che" : "Local Codewind";
         const newConnection = new Connection(LOCAL_CONNECTION_ID, url, label, false);
         this.onNewConnection(newConnection);
         return newConnection;

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -149,11 +149,10 @@ export default class LocalCodewindManager {
     }
 
     /**
-     * Theia Only -
-     * For the theia case where we do not control CW's lifecycle, we simply wait for it to start.
+     * For the Che case where we do not control CW's lifecycle, we simply wait for it to start.
      */
     public async waitForCodewindToStartChe(): Promise<void> {
-        Log.i(`In theia; waiting for Codewind to come up on ${CHE_CW_URL}`);
+        Log.i(`In Che; waiting for Codewind to come up on ${CHE_CW_URL}`);
         this.setState(CodewindStates.STARTING);
         const cheCwUrl = vscode.Uri.parse(CHE_CW_URL);
 
@@ -177,7 +176,7 @@ export default class LocalCodewindManager {
                     return resolve(false);
                 }
                 else if (tries === longerThanUsualTries) {
-                    this.onTheiaStartTimeout(false, tries * delayS);
+                    this.onCheStartTimeout(false, tries * delayS);
                 }
             }, delayS * 1000);
         }).then((result) => {
@@ -196,7 +195,7 @@ export default class LocalCodewindManager {
 
         const isCodewindUp = await waitingForReadyProm;
         if (!isCodewindUp) {
-            this.onTheiaStartTimeout(true, timeoutS);
+            this.onCheStartTimeout(true, timeoutS);
             this.setState(CodewindStates.ERR_CONNECTING);
             return;
         }
@@ -204,7 +203,7 @@ export default class LocalCodewindManager {
         await this.connect(cheCwUrl);
     }
 
-    private onTheiaStartTimeout(failure: boolean, secsElapsed: number): void {
+    private onCheStartTimeout(failure: boolean, secsElapsed: number): void {
         const helpBtn = "Help";
 
         const msg = failure ?

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -128,7 +128,7 @@ export default class LocalCodewindManager {
      * Check if the local Codewind URL has changed due to a command-line restart, and recreate the local connection if it has changed.
      */
     public async refresh(): Promise<boolean> {
-        if (global.isTheia) {
+        if (global.isChe) {
             return false;
         }
 
@@ -152,7 +152,7 @@ export default class LocalCodewindManager {
      * Theia Only -
      * For the theia case where we do not control CW's lifecycle, we simply wait for it to start.
      */
-    public async waitForCodewindToStartTheia(): Promise<void> {
+    public async waitForCodewindToStartChe(): Promise<void> {
         Log.i(`In theia; waiting for Codewind to come up on ${CHE_CW_URL}`);
         this.setState(CodewindStates.STARTING);
         const cheCwUrl = vscode.Uri.parse(CHE_CW_URL);

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -160,8 +160,8 @@ export default class Project implements vscode.QuickPickItem {
         // The function calling the constructor must await on this promise before expecting the project to be ready.
         this.initPromise = Promise.all([
             this.updateCapabilities(),
-            // skip the debug config step in Theia
-            global.isTheia ? Promise.resolve() : this.updateDebugConfig(),
+            // skip the debug config step in Che
+            global.isChe ? Promise.resolve() : this.updateDebugConfig(),
         ])
         .then(() => Promise.resolve());
 

--- a/dev/src/command/CommandUtil.ts
+++ b/dev/src/command/CommandUtil.ts
@@ -258,7 +258,7 @@ export async function promptForConnection(connectedOnly: boolean, remoteOnly: bo
         return choices[0];
     }
     else if (choices.length === 0) {
-        if (global.isTheia) {
+        if (global.isChe) {
             vscode.window.showWarningMessage(`Codewind has not yet started. Wait for the Codewind pod to come up before running this command.`);
         }
         else {

--- a/dev/src/command/StartCodewindCmd.ts
+++ b/dev/src/command/StartCodewindCmd.ts
@@ -29,8 +29,8 @@ export default async function connectLocalCodewindCmd(
     Log.i("Start Local Codewind Cmd");
 
     try {
-        if (global.isTheia) {
-            await LocalCodewindManager.instance.waitForCodewindToStartTheia();
+        if (global.isChe) {
+            await LocalCodewindManager.instance.waitForCodewindToStartChe();
             return;
         }
 

--- a/dev/src/command/connection/CreateUserProjectCmd.ts
+++ b/dev/src/command/connection/CreateUserProjectCmd.ts
@@ -353,7 +353,7 @@ async function promptForProjectName(connection: Connection, template: CWTemplate
  */
 async function getParentDirectory(): Promise<vscode.Uri | undefined> {
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
-        && (global.isTheia || CWConfigurations.ALWAYS_CREATE_IN_WORKSPACE.get())) {
+        && (global.isChe || CWConfigurations.ALWAYS_CREATE_IN_WORKSPACE.get())) {
 
         // if it is a single-root workspace, create the project under that root
         if (vscode.workspace.workspaceFolders.length === 1) {

--- a/dev/src/command/connection/RefreshConnectionCmd.ts
+++ b/dev/src/command/connection/RefreshConnectionCmd.ts
@@ -20,7 +20,7 @@ export default async function refreshConnectionCmd(connection: Connection): Prom
     try {
         if (!connection.isRemote) {
             // If local was restarted outside of the IDE, the IDE will not pick up the new URL until a manual refresh.
-            // In Theia this has no effect
+            // In Che this has no effect
             const localHasChanged = await LocalCodewindManager.instance.refresh();
             if (localHasChanged) {
                 vscode.window.showInformationMessage(`Reconnected to Local Codewind`);

--- a/dev/src/command/webview/RegistriesPageWrapper.ts
+++ b/dev/src/command/webview/RegistriesPageWrapper.ts
@@ -36,7 +36,7 @@ interface ManageRegistriesMsgData {
 
 function getTitle(connection: Connection): string {
     let title = "Image Registry Manager";
-    if (!global.isTheia) {
+    if (!global.isChe) {
         title += ` (${connection.label})`;
     }
     return title;

--- a/dev/src/command/webview/SourcesPageWrapper.ts
+++ b/dev/src/command/webview/SourcesPageWrapper.ts
@@ -33,7 +33,7 @@ const SOURCES_PAGE_TITLE = "Template Source Manager";
 
 function getTitle(connection: Connection): string {
     let title = SOURCES_PAGE_TITLE;
-    if (!global.isTheia) {
+    if (!global.isChe) {
         title += ` (${connection.label})`;
     }
     return title;

--- a/dev/src/command/webview/WebviewUtil.ts
+++ b/dev/src/command/webview/WebviewUtil.ts
@@ -65,7 +65,6 @@ namespace WebviewUtil {
         // These should be loaded first so they can be overridden
         stylesheets.unshift("common.css");
 
-        // Change this to a an if (true) if you're debugging in the browser
         if (global.isTheia || !!process.env[ENVVAR_WEBVIEW_DEBUG_DIR]) {
             stylesheets.unshift("theia.css");
         }

--- a/dev/src/command/webview/WebviewUtil.ts
+++ b/dev/src/command/webview/WebviewUtil.ts
@@ -99,8 +99,8 @@ namespace WebviewUtil {
     }
 
     export function buildTitleSection(rp: WebviewResourceProvider, title: string, connectionLabel: string, isRemoteConnection: boolean): string {
-        // the subtitle is ommitted in theia since there is only one connection
-        const hasSubtitle = !global.isTheia;
+        // the subtitle is ommitted in Che since there is only one connection
+        const hasSubtitle = !global.isChe;
 
         return `<div class="title-section ${hasSubtitle ? "title-section-subtitled" : ""}">
             <div id="logo-container">

--- a/dev/src/command/webview/pages/ProjectOverviewPage.ts
+++ b/dev/src/command/webview/pages/ProjectOverviewPage.ts
@@ -63,7 +63,7 @@ export function getProjectOverviewHtml(rp: WebviewResourceProvider, project: Pro
             ${buildRow(rp, "Type", project.type.toString())}
             ${buildRow(rp, "Language", MCUtil.uppercaseFirstChar(project.language))}
             ${buildRow(rp, "Project ID", project.id)}
-            ${buildRow(rp, "Local Path", getUserFriendlyPath(project), { openable: global.isTheia ? undefined : "folder"})}
+            ${buildRow(rp, "Local Path", getUserFriendlyPath(project), { openable: global.isChe ? undefined : "folder"})}
         </table>
     </div>
     <div class="section">
@@ -264,7 +264,7 @@ function buildContainerPodSection(rp: WebviewResourceProvider, project: Project)
 }
 
 function buildDebugSection(rp: WebviewResourceProvider, project: Project): string {
-    if (global.isTheia) {
+    if (global.isChe) {
         return `
             </table>
         `;

--- a/dev/src/extension.ts
+++ b/dev/src/extension.ts
@@ -46,6 +46,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Declared as 'any' type, but will always be assigned globalState which is a vscode.Memento
     global.extGlobalState = context.globalState;
     global.isTheia = vscode.env.appName.toLowerCase().includes("theia");
+    global.isChe = !!process.env[Constants.CHE_WORKSPACEID_ENVVAR];
 
     Log.setLogFilePath(context);
     Log.i("Finished activating logger");
@@ -95,7 +96,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Connect to local codewind if it's started, but don't start it automatically.
     connectLocalCodewindCmd(LocalCodewindManager.instance, false);
 
-    if (!global.isTheia && CWConfigurations.SHOW_HOMEPAGE.get()) {
+    if (!global.isChe && CWConfigurations.SHOW_HOMEPAGE.get()) {
         showHomePageCmd();
     }
 

--- a/dev/src/global.d.ts
+++ b/dev/src/global.d.ts
@@ -26,6 +26,7 @@ declare namespace NodeJS {
          * If true, the extension is running in Theia, else it is running in VS Code.
          */
         isTheia: boolean,
+        isChe: boolean,
 
         // For some reason, importing anything at the top of this file causes all the properties declared here to not work anymore.
         // So, we use 'any' for extGlobalState - but it's a vscode.Memento.

--- a/dev/src/global.d.ts
+++ b/dev/src/global.d.ts
@@ -26,6 +26,9 @@ declare namespace NodeJS {
          * If true, the extension is running in Theia, else it is running in VS Code.
          */
         isTheia: boolean,
+        /**
+         * If true, the extension is running in Theia in Che.
+         */
         isChe: boolean,
 
         // For some reason, importing anything at the top of this file causes all the properties declared here to not work anymore.

--- a/dev/src/view/CodewindTree.ts
+++ b/dev/src/view/CodewindTree.ts
@@ -39,7 +39,7 @@ export default class CodewindTreeDataProvider implements vscode.TreeDataProvider
         CodewindEventListener.addOnChangeListener(this.refresh);
         Log.d("Finished constructing ProjectTree");
 
-        if (MCUtil.isUserInCwWorkspaceOrProject() || global.isTheia) {
+        if (MCUtil.isUserInCwWorkspaceOrProject() || global.isChe) {
             if (CWConfigurations.AUTO_SHOW_VIEW.get()) {
                 Log.d("Auto-expanding the Codewind view");
                 // reveal the LocalCodewindManager because it is guaranteed to exist

--- a/dev/src/view/TreeItemFactory.ts
+++ b/dev/src/view/TreeItemFactory.ts
@@ -34,8 +34,8 @@ namespace TreeItemFactory {
         const cwStarted = LocalCodewindManager.instance.isStarted;
 
         let label = "Local";
-        if (global.isTheia) {
-            // it's confusing to say "local" in Theia
+        if (global.isChe) {
+            // it's confusing to say "local" in Che
             label = "Projects";
         }
         // Show state except when started (since it's obvious in that case).


### PR DESCRIPTION
- Also rename build artifact from codewind-theia.vsix to codewind-che.vsix

Towards https://github.com/eclipse/codewind/issues/2202