### PR TITLE
Add fallback font-families in webviews

### DIFF
--- a/dev/res/css/common.css
+++ b/dev/res/css/common.css
@@ -3,7 +3,7 @@ body {
     padding-left: 5%;
     padding-right: 5%;
     padding-bottom: 2%;
-    font-family: "IBM Plex Sans";
+    font-family: 'IBM Plex Sans', Arial, Helvetica, sans-serif;
 
     /* This colour is taken from the VS Code welcome page, but doesn't appear to be available in other webviews. */
     --welcomePage-tileBackground: #171717;


### PR DESCRIPTION
sans-serif font should always be used since the Windows default looks bad

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
