### PR TITLE
Fix wrong credentials breaking remote connection

### DIFF
--- a/dev/src/codewind/Requester.ts
+++ b/dev/src/codewind/Requester.ts
@@ -121,7 +121,7 @@ export class Requester {
      * Try to connect to the given URL. Returns true if any response is returned that does not have one of the `rejectedStatusCodes`.
      */
     public static async ping(url: string | vscode.Uri, timeoutMS: number, ...rejectStatusCodes: number[]): Promise<boolean> {
-        // Log.d(`Ping ${url}`);
+        Log.d(`Pinging ${url}`);
         if (url instanceof vscode.Uri) {
             url = url.toString();
         }

--- a/dev/src/codewind/cli/CLIWrapper.ts
+++ b/dev/src/codewind/cli/CLIWrapper.ts
@@ -222,11 +222,16 @@ namespace CLIWrapper {
                     }
                     // Log.d("CLI object output:", outStr);
 
-                    const obj = JSON.parse(outStr);
-                    if (obj.error_description) {
-                        return reject(obj.error_description);
+                    try {
+                        const obj = JSON.parse(outStr);
+                        if (obj.error_description) {
+                            return reject(obj.error_description);
+                        }
+                        return resolve(obj);
                     }
-                    return resolve(obj);
+                    catch (err) {
+                        return reject(err);
+                    }
                 }
             });
         }).finally(() => {

--- a/dev/src/codewind/connection/RemoteConnection.ts
+++ b/dev/src/codewind/connection/RemoteConnection.ts
@@ -82,6 +82,12 @@ export default class RemoteConnection extends Connection {
             throw new Error(`Failed to connect to ${this.url}. Make sure the Codewind instance is running, and reachable from your machine.`);
         }
 
+        if ((await this.getAccessToken()) == null) {
+            this.setState(ConnectionStates.AUTH_ERROR);
+            throw new Error(`Authentication error. Make sure your credentials are correct, ` +
+                `and that "${this.username}" has access to this Codewind instance.`);
+        }
+
         try {
             await super.enable();
             if (!this._socket) {


### PR DESCRIPTION
Also fix a problem where cwctl output that started with '{' but was not JSON could leave a hanging promise

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
