### PR TITLE
Improve CLI setup error reporting

### DIFF
--- a/dev/src/codewind/cli/CLIWrapper.ts
+++ b/dev/src/codewind/cli/CLIWrapper.ts
@@ -20,11 +20,11 @@ import { CLILifecycleCommand } from "./CLILifecycleCommands";
 import { CLICommand } from "./CLICommands";
 import CLISetup from "./CLISetup";
 
-const cliOutputChannel = vscode.window.createOutputChannel("Codewind");
-
 let _hasInitialized = false;
 
 namespace CLIWrapper {
+
+    export const cliOutputChannel = vscode.window.createOutputChannel("Codewind");
 
     export function hasInitialized(): boolean {
         return _hasInitialized;
@@ -44,10 +44,18 @@ namespace CLIWrapper {
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Window,
             cancellable: false,
-            title: `Initializing Codewind...`,
+            title: `Setting up Codewind...`,
         }, async () => {
             if (await CLISetup.doesBinariesTargetDirExist()) {
-                [ isCwctlSetup, isAppsodySetup ] = await Promise.all([ CLISetup.isCwctlSetup(), CLISetup.isAppsodySetup() ]);
+                cliOutputChannel.appendLine(`${CLISetup.getBinariesTargetDir()} exists`);
+
+                [ isCwctlSetup, isAppsodySetup ] = await Promise.all([
+                    CLISetup.isCwctlSetup(),
+                    CLISetup.isAppsodySetup()
+                ]);
+            }
+            else {
+                cliOutputChannel.appendLine(`${CLISetup.getBinariesTargetDir()} was created`);
             }
         });
         Log.d(`Finished determining if binaries are installed, took ${Date.now() - binariesInitStartTime}ms`);

--- a/dev/src/codewind/connection/local/CodewindStates.ts
+++ b/dev/src/codewind/connection/local/CodewindStates.ts
@@ -11,13 +11,14 @@
 
 export enum CodewindStates {
     SETUP = "Setting up",
+    ERR_SETUP = "Error setting up",
     STOPPED = "Stopped",
     STARTED = "Started",
     STARTING = "Starting",
     STOPPING = "Stopping",
     INSTALLING = "Installing",
-    ERR_INSTALLING = "Error installing",
-    ERR_STARTING = "Error starting",
+    ERR_INSTALLING = "Error pulling images",
+    ERR_STARTING = "Error starting containers",
     ERR_CONNECTING = "Error connecting",
     ERR_GENERIC = "Error",
 }

--- a/dev/src/extension.ts
+++ b/dev/src/extension.ts
@@ -118,7 +118,10 @@ async function activateInner(context: vscode.ExtensionContext): Promise<void> {
     })
     .catch((err) => {
         Log.e(`Uncaught error in async initialize!`, err);
-        vscode.window.showErrorMessage(`Unexpected error activating Codewind: ${MCUtil.errToString(err)}`);
+        const userErrMsg = `Error activating Codewind: ${MCUtil.errToString(err)}`;
+        CLIWrapper.showCLIError(userErrMsg);
+        CLIWrapper.cliOutputChannel.appendLine(userErrMsg);
+        LocalCodewindManager.instance.setState(CodewindStates.ERR_SETUP);
     });
 
     Log.d("Finished activating");


### PR DESCRIPTION
- Prompt user to open output if CLI setup fails
- Show a progress notification if cli.properties download is slow
    - Fixes https://github.com/eclipse/codewind/issues/2610

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
