### PR TITLE
Improve some behaviours around connection enablement

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -512,7 +512,12 @@
                 },
                 {
                     "command": "%cmdID_refreshConnection%",
-                    "when": "%isConnection%",
+                    "when": "%isLocalCodewind%",
+                    "group": "ext.cw.conn.d@1"
+                },
+                {
+                    "command": "%cmdID_refreshConnection%",
+                    "when": "%isEnabledRemoteConnection%",
                     "group": "ext.cw.conn.d@1"
                 },
                 {

--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -147,6 +147,7 @@
         "See TreeItemFactory / TreeItemContext for how the Context IDs are set"
     ],
 
+    "isLocalCodewind": "viewItem =~ /.*local.*/",
     "isStoppedLocalCodewind": "viewItem =~ /.*local\\.stopped.*/",
     "isStartedLocalCodewind": "viewItem =~ /.*local\\.started.*/",
 

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -87,12 +87,17 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         this.requester = new ConnectionRequester(this);
         this.pfeHost = this.getPFEHost();
 
-        this.enable()
-        .catch((err) => {
-            const errMsg = `Error initializing Codewind connection:`;
-            Log.e(errMsg, err);
-            vscode.window.showErrorMessage(`${errMsg} ${MCUtil.errToString(err)}`);
-        });
+        if (this.shouldEnableInitially()) {
+            this.enable()
+            .catch((err) => {
+                const errMsg = `Error initializing ${this.label}:`;
+                Log.e(errMsg, err);
+                vscode.window.showErrorMessage(`${errMsg} ${MCUtil.errToString(err)}`);
+            });
+        }
+        else {
+            this.setState(ConnectionStates.DISABLED);
+        }
     }
 
     public get enabled(): boolean {
@@ -111,6 +116,10 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
 
     public get isConnected(): boolean {
         return this._state.isConnected;
+    }
+
+    protected shouldEnableInitially(): boolean {
+        return true;
     }
 
     protected async enable(): Promise<void> {
@@ -207,6 +216,10 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
 
     public async dispose(): Promise<void> {
         return this.disable();
+    }
+
+    public async onRemove(): Promise<void> {
+        // nothing for local
     }
 
     public toString(): string {

--- a/dev/src/codewind/connection/ConnectionManager.ts
+++ b/dev/src/codewind/connection/ConnectionManager.ts
@@ -28,7 +28,10 @@ export default class ConnectionManager implements vscode.Disposable {
     private readonly _connections: Connection[] = [];
 
     public static get instance(): ConnectionManager {
-        return ConnectionManager._instance || (ConnectionManager._instance = new ConnectionManager());
+        if (ConnectionManager._instance == null) {
+            ConnectionManager._instance = new ConnectionManager();
+        }
+        return ConnectionManager._instance;
     }
 
     public async activate(): Promise<void> {
@@ -102,7 +105,7 @@ export default class ConnectionManager implements vscode.Disposable {
     }
 
     public async connectLocal(url: vscode.Uri): Promise<Connection> {
-        if (this.connections[0] && !this.connections[0].isRemote) {
+        if (this.connections[0] != null && !this.connections[0].isRemote) {
             return this.connections[0];
         }
         Log.i("Creating connection to " + url);

--- a/dev/src/codewind/connection/ConnectionManager.ts
+++ b/dev/src/codewind/connection/ConnectionManager.ts
@@ -141,6 +141,7 @@ export default class ConnectionManager implements vscode.Disposable {
             await CLICommandRunner.removeConnection(connection.id);
         }
         connection.dispose();
+        connection.onRemove();
         this.connections.splice(indexToRemove, 1);
         Log.i(`Removed connection ${connection}`);
         CodewindEventListener.onChange(undefined);

--- a/dev/src/codewind/connection/local/LocalCodewindManager.ts
+++ b/dev/src/codewind/connection/local/LocalCodewindManager.ts
@@ -169,7 +169,7 @@ export default class LocalCodewindManager {
             const interval = setInterval(async () => {
                 tries++;
                 const pingResult = await Requester.ping(CHE_CW_URL, delayS * 1000);
-                if (pingResult) {
+                if (pingResult === "success") {
                     clearInterval(interval);
                     return resolve(true);
                 }

--- a/dev/src/codewind/connection/registries/ImageRegistryUtils.ts
+++ b/dev/src/codewind/connection/registries/ImageRegistryUtils.ts
@@ -79,7 +79,7 @@ namespace ImageRegistryUtils {
         // Log.d(`Image push registry response`, pushRegistryRes);
 
         // tslint:disable-next-line: no-boolean-literal-compare
-        if (pushRegistryRes && pushRegistryRes.imagePushRegistry === true) {
+        if (pushRegistryRes != null && pushRegistryRes.imagePushRegistry === true) {
             const pushRegistry = registries.find((reg) => reg.address === pushRegistryRes.address);
             if (!pushRegistry) {
                 Log.e(`Push registry response was ${JSON.stringify(pushRegistryRes)} but no registry with a matching address was found`);

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -1046,7 +1046,7 @@ export default class Project implements vscode.QuickPickItem {
 
         Log.i(`Testing ${this.name} perf dash before opening`);
         try {
-            return Requester.ping(this.metricsDashboardURL, 5000, 404);
+            return (await Requester.ping(this.metricsDashboardURL, 5000, [ 404 ]) === "success");
         }
         catch (err) {
             Log.w(`Failed to access app monitor for project ${this.name} at ${this.metricsDashboardURL}`, err);

--- a/dev/src/codewind/project/ProjectState.ts
+++ b/dev/src/codewind/project/ProjectState.ts
@@ -161,7 +161,7 @@ export class ProjectState {
         }
 
         this.notificationIDsShown.push(this.appDetail.notificationID);
-        Log.i(`Showing user detailed app status ${this.appDetail.message} for project ${this.projectName}`);
+        Log.i(`Showing user detailed app status "${this.appDetail.message}" for project ${this.projectName}`);
 
         // https://github.com/eclipse/codewind/issues/1812
         let helpLinkBtn: string | undefined;

--- a/dev/src/codewind/project/ProjectState.ts
+++ b/dev/src/codewind/project/ProjectState.ts
@@ -143,7 +143,7 @@ export class ProjectState {
     }
 
     public getAppStatusWithDetail(): string {
-        if (!this.appState || this.appState === ProjectState.AppStates.UNKNOWN) {
+        if (this.appState == null || this.appState === ProjectState.AppStates.UNKNOWN) {
             return "";
         }
 

--- a/dev/src/command/CommandUtil.ts
+++ b/dev/src/command/CommandUtil.ts
@@ -23,7 +23,7 @@ import toggleEnablementCmd from "./project/ToggleEnablementCmd";
 import projectOverviewCmd from "./project/ProjectOverviewCmd";
 import toggleAutoBuildCmd from "./project/ToggleAutoBuildCmd";
 import openMetricsDashboardCmd from "./project/OpenMetricsDashboard";
-import refreshConnectionCmd from "./connection/RefreshConnectionCmd";
+import { refreshConnectionCmd, refreshLocalCWCmd } from "./connection/RefreshConnectionCmd";
 import { manageLogs, showAllLogs, hideAllLogs } from "./project/ManageLogsCmd";
 import createProjectCmd from "./connection/CreateUserProjectCmd";
 import bindProjectCmd from "./connection/BindProjectCmd";
@@ -74,7 +74,21 @@ export function createCommands(): vscode.Disposable[] {
         registerConnectionCommand(Commands.REMOVE_CONNECTION, removeConnectionCmd, [], false, true),
         registerConnectionCommand(Commands.ENABLE_CONNECTION, toggleConnectionEnablementCmd, [ true ], false, true),
         registerConnectionCommand(Commands.DISABLE_CONNECTION, toggleConnectionEnablementCmd, [ false ], false, true),
-        registerConnectionCommand(Commands.REFRESH_CONNECTION, refreshConnectionCmd, [], false, false),
+        // registerConnectionCommand(Commands.REFRESH_CONNECTION, refreshConnectionCmd, [], false, false),
+
+        // the refresh command is unique because it's valid for the stopped local connection, as well as regular, connected connections.
+        vscode.commands.registerCommand(Commands.REFRESH_CONNECTION, async (selection: LocalCodewindManager | Connection | undefined) => {
+            if (selection instanceof LocalCodewindManager) {
+                return refreshLocalCWCmd();
+            }
+            else if (selection == null) {
+                selection = await promptForConnection(true, false);
+                if (selection == null) {
+                    return;
+                }
+            }
+            return refreshConnectionCmd(selection);
+        }),
 
         registerConnectionCommand(Commands.CREATE_PROJECT, createProjectCmd, [], true, false),
         registerConnectionCommand(Commands.BIND_PROJECT, bindProjectCmd, [], true, false),

--- a/dev/src/command/connection/BindProjectCmd.ts
+++ b/dev/src/command/connection/BindProjectCmd.ts
@@ -158,7 +158,7 @@ async function promptForProjectType(connection: Connection, detected: IDetectedP
     });
     projectTypeQpis.sort((a, b) => a.label.localeCompare(b.label));
     // Add "other" option last
-    if (dockerType) {
+    if (dockerType != null) {
         projectTypeQpis.push(dockerType);
     }
 

--- a/dev/src/command/connection/CreateUserProjectCmd.ts
+++ b/dev/src/command/connection/CreateUserProjectCmd.ts
@@ -97,11 +97,6 @@ export default async function createProjectCmd(connection: Connection): Promise<
         }
 
         const response = await createProject(connection, template, parentDir, projectName);
-        if (!response) {
-            // user cancelled
-            return;
-        }
-
         vscode.window.showInformationMessage(`Created project ${response.projectName} at ${MCUtil.containerPathToFsPath(response.projectPath)}`);
     }
     catch (err) {

--- a/dev/src/command/connection/ToggleConnectionEnablement.ts
+++ b/dev/src/command/connection/ToggleConnectionEnablement.ts
@@ -17,7 +17,7 @@ import Log from "../../Logger";
 import RemoteConnection from "../../codewind/connection/RemoteConnection";
 import MCUtil from "../../MCUtil";
 import remoteConnectionSettingsCmd from "./ConnectionOverviewCmd";
-import refreshConnectionCmd from "./RefreshConnectionCmd";
+import { refreshConnectionCmd } from "./RefreshConnectionCmd";
 
 export default async function toggleConnectionEnablementCmd(connection_: Connection, enable: boolean): Promise<void> {
     if (!connection_.isRemote) {
@@ -39,6 +39,11 @@ export default async function toggleConnectionEnablementCmd(connection_: Connect
     }
 
     Log.i(`${enable ? "Enable" : "Disable"} ${connection.label}`);
+
+    if (!connection.canToggleEnablement()) {
+        Log.t(`Blocking toggle operation for ${connection.label}`);
+        return;
+    }
 
     try {
         await vscode.window.withProgress({

--- a/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ConnectionOverviewPageWrapper.ts
@@ -232,7 +232,10 @@ export default class ConnectionOverviewWrapper extends WebviewWrapper {
         }, async () => {
             const canPing = await Requester.pingKube(ingressUrl, 5000);
 
-            if (!canPing) {
+            if (canPing === "cancelled") {
+                throw new Error(CLIWrapper.CLI_CMD_CANCELLED);
+            }
+            else if (canPing === "failure") {
                 throw new Error(`Failed to contact ${ingressUrl}. Make sure this URL is reachable.`);
             }
 

--- a/dev/src/view/CodewindTree.ts
+++ b/dev/src/view/CodewindTree.ts
@@ -39,17 +39,24 @@ export default class CodewindTreeDataProvider implements vscode.TreeDataProvider
         CodewindEventListener.addOnChangeListener(this.refresh);
         Log.d("Finished constructing ProjectTree");
 
-        if (MCUtil.isUserInCwWorkspaceOrProject() || global.IS_CHE) {
+        this.tryReveal()
+        .catch((err) => {
+            Log.e(`Failed to auto-reveal the Codewind view`, err);
+        });
+
+        // this.treeView.onDidChangeSelection((e) => {
+        //     Log.d("Selection is now", e.selection[0]);
+        // });
+    }
+
+    private async tryReveal(): Promise<void> {
+        if (await MCUtil.isUserInCwWorkspaceOrProject() || global.IS_CHE) {
             if (CWConfigurations.AUTO_SHOW_VIEW.get()) {
                 Log.d("Auto-expanding the Codewind view");
                 // reveal the LocalCodewindManager because it is guaranteed to exist
                 this.treeView.reveal(LocalCodewindManager.instance);
             }
         }
-
-        // this.treeView.onDidChangeSelection((e) => {
-        //     Log.d("Selection is now", e.selection[0]);
-        // });
     }
 
     /**

--- a/dev/tslint.json
+++ b/dev/tslint.json
@@ -11,10 +11,13 @@
 		"ordered-imports": false,
 		"trailing-comma": false,
 		"typedef-whitespace": false,
-		"variable-name": [ true, "allow-leading-underscore", "allow-trailing-underscore", "allow-pascal-case" ],
+		"variable-name": [ true,
+			"allow-leading-underscore",
+			"allow-trailing-underscore",
+			"allow-pascal-case"
+		],
 
-		"await-promise": [
-			true,
+		"await-promise": [ true,
 			"Thenable",
 			"RequestPromise",
 			"requestPromise.RequestPromise"
@@ -23,8 +26,7 @@
 			[ "For test use only", "Log",  "t" ]
 		],
 		"deprecation": true,
-		"max-line-length": [
-			true,
+		"max-line-length": [ true,
 			{
 				"limit": 150,
 				"check-strings": true
@@ -34,16 +36,23 @@
 		"no-duplicate-variable": true,
 		"no-invalid-template-strings": true,
 		"no-invalid-this": true,
+		"no-switch-case-fall-through": true,
 		"no-require-imports": true,
 		"no-unused-expression": true,
 		"no-var-keyword": true,
 		"object-literal-key-quotes": [ true, "as-needed" ],
 		"prefer-const": true,
 		"prefer-readonly": true,
+		"strict-boolean-expressions": [ true,
+			"allow-null-union",
+			"allow-undefined-union",
+			"allow-string",
+			"allow-number",
+			"allow-mix",
+			"ignore-rhs"
+		],
 		"switch-default": true,
-		"no-switch-case-fall-through": true,
-		"typedef": [
-			true,
+		"typedef": [ true,
 			"array-destructuring",
 			"call-signature",
 			"member-variable-declaration",


### PR DESCRIPTION
Pls rebase and merge

commit bdf4365c1f879bcd9b0e3f64c56caf1ec293a7a8
Author: Tim Etchells <timetchells@ibm.com>
Date:   Mon May 4 18:11:42 2020 -0400

    Persist connection disabled-ness
    
    Fixes https://github.com/eclipse/codewind/issues/2823
    
    Signed-off-by: Tim Etchells <timetchells@ibm.com>

commit 14967cb8dddff3c7f9713921035adb2fe4bc8d2e
Author: Tim Etchells <timetchells@ibm.com>
Date:   Mon May 4 17:28:14 2020 -0400

    Cancel connection enablement if disposed
    
    - Improve message when trying to toggle a 'busy' connection
    - Fixes https://github.com/eclipse/codewind/issues/2824
    - Also fix a problem with the local refresh command not working if local codewind is stopped
    
    Signed-off-by: Tim Etchells <timetchells@ibm.com>

commit 8812e4d05fa853a5dca75ed7cad8c8c1aa719958
Author: Tim Etchells <timetchells@ibm.com>
Date:   Mon May 4 12:09:47 2020 -0400

    Enable strict boolean expressions
    
    Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
