### PR TITLE
Fix remove project

### DIFF
--- a/dev/src/codewind/cli/CLICommandRunner.ts
+++ b/dev/src/codewind/cli/CLICommandRunner.ts
@@ -113,14 +113,19 @@ export namespace CLICommandRunner {
         return bindRes;
     }
 
-    export async function removeProject(projectID: string, deleteFiles: boolean): Promise<void> {
+    export async function removeProject(projectID: string /*, deleteFiles: boolean */): Promise<void> {
         const removeArgs = [
             "--id", projectID,
         ];
 
-        if (deleteFiles) {
-            removeArgs.push("--delete");
-        }
+        // deleteFiles is not used anymore because it proved more trouble than it was worth.
+        // By deleting the files from this process, we don't have to worry about permissions errors on Windows with VS Code still reading the files
+        // - since we delete them from the same process, it's allowed.
+        // https://github.com/eclipse/codewind/issues/2456
+
+        // if (deleteFiles) {
+            // removeArgs.push("--delete");
+        // }
 
         await CLIWrapper.cwctlExec(CLICommands.PROJECT.REMOVE, removeArgs);
     }

--- a/dev/src/codewind/cli/CLICommandRunner.ts
+++ b/dev/src/codewind/cli/CLICommandRunner.ts
@@ -118,10 +118,8 @@ export namespace CLICommandRunner {
             "--id", projectID,
         ];
 
-        // deleteFiles is not used anymore because it proved more trouble than it was worth.
-        // By deleting the files from this process, we don't have to worry about permissions errors on Windows with VS Code still reading the files
-        // - since we delete them from the same process, it's allowed.
-        // https://github.com/eclipse/codewind/issues/2456
+        // deleteFiles is not used anymore because we have to delete the files well after the removal from Codewind.
+        // see https://github.com/eclipse/codewind/issues/2456
 
         // if (deleteFiles) {
             // removeArgs.push("--delete");

--- a/dev/src/codewind/connection/Connection.ts
+++ b/dev/src/codewind/connection/Connection.ts
@@ -319,7 +319,6 @@ export default class Connection implements vscode.QuickPickItem, vscode.Disposab
         this.setState(ConnectionStates.NETWORK_ERROR);
 
         this._projects.forEach((p) => p.onConnectionDisconnect());
-        this._projects = [];
 
         Log.i(`${this} is now disconnected`);
 

--- a/dev/src/command/connection/CreateUserProjectCmd.ts
+++ b/dev/src/command/connection/CreateUserProjectCmd.ts
@@ -390,7 +390,7 @@ export async function createProject(connection: Connection, template: CWTemplate
     const creationResult = await vscode.window.withProgress({
         cancellable: false,
         location: vscode.ProgressLocation.Notification,
-        title: `Creating ${projectName}...`
+        title: `Creating ${projectName} into ${projectPath}...`
     }, async () => {
         const creationRes = await CLICommandRunner.createProject(connection.id, projectPath, template.url);
         if (creationRes.status !== SocketEvents.STATUS_SUCCESS) {

--- a/dev/src/command/project/ChangeProjectConnectionCmd.ts
+++ b/dev/src/command/project/ChangeProjectConnectionCmd.ts
@@ -17,7 +17,7 @@ import ConnectionManager from "../../codewind/connection/ConnectionManager";
 import toggleEnablementCmd from "./ToggleEnablementCmd";
 import { addProjectToConnection } from "../connection/BindProjectCmd";
 import RegistryUtils from "../../codewind/connection/registries/ImageRegistryUtils";
-import { removeProject } from "./RemoveProjectCmd";
+import removeProjectCmd from "./RemoveProjectCmd";
 import MCUtil from "../../MCUtil";
 import { IDetectedProjectType } from "../../codewind/Types";
 
@@ -109,7 +109,7 @@ export default async function changeProjectConnectionCmd(project: Project): Prom
         }
 
         if (existingActionResponse === optionRemove) {
-            await removeProject(project, false);
+            await removeProjectCmd(project, false);
         }
         else if (existingActionResponse === optionDisable) {
             await toggleEnablementCmd(project);

--- a/dev/src/command/project/ChangeProjectConnectionCmd.ts
+++ b/dev/src/command/project/ChangeProjectConnectionCmd.ts
@@ -17,7 +17,6 @@ import ConnectionManager from "../../codewind/connection/ConnectionManager";
 import toggleEnablementCmd from "./ToggleEnablementCmd";
 import { addProjectToConnection } from "../connection/BindProjectCmd";
 import RegistryUtils from "../../codewind/connection/registries/ImageRegistryUtils";
-import removeProjectCmd from "./RemoveProjectCmd";
 import MCUtil from "../../MCUtil";
 import { IDetectedProjectType } from "../../codewind/Types";
 
@@ -109,7 +108,7 @@ export default async function changeProjectConnectionCmd(project: Project): Prom
         }
 
         if (existingActionResponse === optionRemove) {
-            await removeProjectCmd(project, false);
+            await project.deleteFromConnection(false);
         }
         else if (existingActionResponse === optionDisable) {
             await toggleEnablementCmd(project);

--- a/dev/src/command/project/RemoveProjectCmd.ts
+++ b/dev/src/command/project/RemoveProjectCmd.ts
@@ -18,9 +18,6 @@ import MCUtil from "../../MCUtil";
 import Project from "../../codewind/project/Project";
 import ConnectionManager from "../../codewind/connection/ConnectionManager";
 
-/**
- * @param deleteFiles - Set this to skip prompting the user, and instead just do the remove silently.
- */
 export default async function removeProjectCmd(project: Project): Promise<void> {
     let deleteFiles: boolean;
 
@@ -62,9 +59,9 @@ export default async function removeProjectCmd(project: Project): Promise<void> 
 
         deleteFiles = deleteDirRes === deleteDirBtn;
     }
-    
+
     // We do not await the deleteFromCodewind since it modifies the workspace folders.
-    // If the workspace folder modification results in a reload, this command will get canceled 
+    // If the workspace folder modification results in a reload, this command will get canceled
     // and an error message is shown that this command was canceled.
     // so by not awaiting, this command finishes early, but we don't have to worry about the cancellation.
 

--- a/dev/src/command/project/RemoveProjectCmd.ts
+++ b/dev/src/command/project/RemoveProjectCmd.ts
@@ -18,65 +18,61 @@ import MCUtil from "../../MCUtil";
 import Project from "../../codewind/project/Project";
 import ConnectionManager from "../../codewind/connection/ConnectionManager";
 
-export default async function removeProjectCmd(project: Project): Promise<void> {
+/**
+ * @param deleteFiles - Set this to skip prompting the user, and instead just do the remove silently.
+ */
+export default async function removeProjectCmd(project: Project, deleteFiles?: boolean): Promise<void> {
     try {
-        await removeProject(project, undefined);
+        let doDeleteProjectDir: boolean;
+
+        if (deleteFiles == null) {
+            // ask the user
+            const deleteMsg = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteProjectMsg", {
+                projectName: project.name,
+                connectionLabel: project.connection.label
+            });
+            const deleteBtn = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteBtn", { projectName: project.name });
+
+            const deleteRes = await vscode.window.showInformationMessage(deleteMsg, { modal: true }, deleteBtn);
+            if (deleteRes !== deleteBtn) {
+                // cancelled
+                return;
+            }
+
+            const projectDirPath: string = project.localPath.fsPath;
+            const isProjectBoundElsewhere = ConnectionManager.instance.connections
+                .some((conn) => conn !== project.connection && conn.hasProjectAtPath(project.localPath));
+
+            if (isProjectBoundElsewhere) {
+                // Another connection is using this project, so we should not delete its files.
+                doDeleteProjectDir = false;
+            }
+            else {
+                // Ask user if they want to delete the files on disk too.
+                const cancelBtn = global.IS_THEIA ? "Close" : "Cancel";
+
+                const deleteDirMsg = Translator.t(StringNamespaces.CMD_MISC, "alsoDeleteDirMsg", {
+                    projectName: project.name,
+                    connectionLabel: project.connection.label,
+                    dirPath: projectDirPath,
+                    cancelBtn,
+                });
+
+                const deleteDirBtn = Translator.t(StringNamespaces.CMD_MISC, "alsoDeleteDirBtn");
+                const deleteDirRes = await vscode.window.showWarningMessage(deleteDirMsg, { modal: true }, deleteDirBtn);
+
+                doDeleteProjectDir = deleteDirRes === deleteDirBtn;
+            }
+        }
+        else {
+            doDeleteProjectDir = deleteFiles;
+        }
+
+        await project.deleteFromCodewind(doDeleteProjectDir);
     }
     catch (err) {
         const errMsg = `Failed to remove ${project.name}`;
         Log.e(errMsg, err);
         vscode.window.showInformationMessage(`${errMsg}: ${MCUtil.errToString(err)}`);
     }
-}
-
-/**
- * @param deleteFiles - Set this to skip prompting the user, and instead just do the unbind silently.
- */
-export async function removeProject(project: Project, deleteFiles: boolean | undefined): Promise<void> {
-    let doDeleteProjectDir: boolean;
-
-    if (deleteFiles == null) {
-        // ask the user
-        const deleteMsg = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteProjectMsg", {
-            projectName: project.name,
-            connectionLabel: project.connection.label
-        });
-        const deleteBtn = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteBtn", { projectName: project.name });
-
-        const deleteRes = await vscode.window.showInformationMessage(deleteMsg, { modal: true }, deleteBtn);
-        if (deleteRes !== deleteBtn) {
-            // cancelled
-            return;
-        }
-
-        const projectDirPath: string = project.localPath.fsPath;
-        const isProjectBoundElsewhere = ConnectionManager.instance.connections
-            .some((conn) => conn !== project.connection && conn.hasProjectAtPath(project.localPath));
-
-        if (isProjectBoundElsewhere) {
-            // Another connection is using this project, so we cannot delete its files.
-            doDeleteProjectDir = false;
-        }
-        else {
-            // Ask user if they want to delete the files on disk too.
-            const cancelBtn = global.IS_THEIA ? "Close" : "Cancel";
-
-            const deleteDirMsg = Translator.t(StringNamespaces.CMD_MISC, "alsoDeleteDirMsg", {
-                projectName: project.name,
-                connectionLabel: project.connection.label,
-                dirPath: projectDirPath,
-                cancelBtn,
-            });
-
-            const deleteDirBtn = Translator.t(StringNamespaces.CMD_MISC, "alsoDeleteDirBtn");
-            const deleteDirRes = await vscode.window.showWarningMessage(deleteDirMsg, { modal: true }, deleteDirBtn);
-
-            doDeleteProjectDir = deleteDirRes === deleteDirBtn;
-        }
-    }
-    else {
-        doDeleteProjectDir = deleteFiles;
-    }
-
-    await project.deleteFromCodewind(doDeleteProjectDir);
 }

--- a/dev/src/command/webview/ProjectOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ProjectOverviewPageWrapper.ts
@@ -77,7 +77,7 @@ export default class ProjectOverviewPageWrapper extends WebviewWrapper {
                 break;
             }
             case ProjectOverviewWVMessages.UNBIND: {
-                removeProjectCmd(this.project, undefined);
+                removeProjectCmd(this.project);
                 break;
             }
             case ProjectOverviewWVMessages.EDIT: {

--- a/dev/src/command/webview/ProjectOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ProjectOverviewPageWrapper.ts
@@ -19,7 +19,7 @@ import Log from "../../Logger";
 import toggleAutoBuildCmd from "../project/ToggleAutoBuildCmd";
 import toggleEnablementCmd from "../project/ToggleEnablementCmd";
 import requestBuildCmd from "../project/RequestBuildCmd";
-import { removeProject } from "../project/RemoveProjectCmd";
+import removeProjectCmd from "../project/RemoveProjectCmd";
 import { getProjectOverviewHtml } from "./pages/ProjectOverviewPage";
 import remoteConnectionOverviewCmd from "../connection/ConnectionOverviewCmd";
 import Commands from "../../constants/Commands";
@@ -77,7 +77,7 @@ export default class ProjectOverviewPageWrapper extends WebviewWrapper {
                 break;
             }
             case ProjectOverviewWVMessages.UNBIND: {
-                removeProject(this.project, undefined);
+                removeProjectCmd(this.project, undefined);
                 break;
             }
             case ProjectOverviewWVMessages.EDIT: {

--- a/dev/src/command/webview/WebviewWrapper.ts
+++ b/dev/src/command/webview/WebviewWrapper.ts
@@ -158,10 +158,21 @@ export abstract class WebviewWrapper {
         }
 
         WebviewUtil.debugWriteOutWebview(newHtml, `${MCUtil.slug(this.title)}.html`);
-        // Setting the html to "" seems to clear the page state, otherwise there is some caching done
-        // which causes eg. the selected radiobutton to not be updated https://github.com/eclipse/codewind/issues/1413
-        this.webPanel.webview.html = "";
-        this.webPanel.webview.html = newHtml;
+
+        try {
+            // Setting the html to "" seems to clear the page state, otherwise there is some caching done
+            // which causes eg. the selected radiobutton to not be updated https://github.com/eclipse/codewind/issues/1413
+            this.webPanel.webview.html = "";
+            this.webPanel.webview.html = newHtml;
+        }
+        catch (err) {
+            const errMsg = `Error refreshing webview ${this.title}`;
+            Log.e(errMsg, err);
+            // don't display the 'webview is dipsosed' message to the user since it has no user impact.
+            if (err.message && !err.message.toString().toLowerCase().includes("webview is disposed")) {
+                vscode.window.showErrorMessage(`${errMsg}: ${MCUtil.errToString(err)}`);
+            }
+        }
     }
 
     protected async abstract generateHtml(resourceProvider: WebviewResourceProvider): Promise<string>;

--- a/dev/src/constants/Constants.ts
+++ b/dev/src/constants/Constants.ts
@@ -33,6 +33,13 @@ namespace Constants {
      * Set this env var to anything to disable the appsody version check
      */
     export const ENV_APPSODY_DEVMODE = "APPSODY_DEV";
+
+    /**
+     * This is checked on activation to see if there are any projects that should have been removed, 
+     * but were not due to the extension reloading.
+     * See Project.onDeletionEvent
+     */
+    export const DIR_TO_DELETE_KEY = "project-dir-to-delete";
 }
 
 export default Constants;

--- a/dev/src/test/Index.ts
+++ b/dev/src/test/Index.ts
@@ -33,7 +33,7 @@ suites = suites.map((suite) => path.join(__dirname, "suites", suite) + ".suite.j
 
 export async function run(): Promise<void> {
 
-    if (TestConfig.isJenkins()) {
+    if (TestConfig.isJenkins() && await fs.pathExists(CLISetup.DOT_CODEWIND_DIR)) {
         // delete all the binary dirs so the tests have to test the pull each time
         const binaryDirs = (await fs.readdir(CLISetup.DOT_CODEWIND_DIR)).filter((dirname) => dirname === "latest" || /\d+\.\d+\.\d+/.test(dirname));
         await Promise.all(binaryDirs.map((dir) => {

--- a/dev/src/test/project/Removal.test.ts
+++ b/dev/src/test/project/Removal.test.ts
@@ -13,7 +13,7 @@ import { expect } from "chai";
 import * as fs from "fs-extra";
 
 import TestUtil from "../TestUtil";
-import { removeProject } from "../../command/project/RemoveProjectCmd";
+import removeProjectCmd from "../../command/project/RemoveProjectCmd";
 
 import { testProjects } from "./Creation.test";
 
@@ -37,7 +37,7 @@ describe(`Project removal wrapper`, function() {
 
                     projectPath = project.localPath.fsPath;
 
-                    await removeProject(project, true);
+                    await removeProjectCmd(project, true);
 
                     await TestUtil.waitForCondition(this, {
                         label: `Waiting for ${project.name} to be removed from ${project.connection.label}`,

--- a/dev/src/test/project/Removal.test.ts
+++ b/dev/src/test/project/Removal.test.ts
@@ -13,7 +13,6 @@ import { expect } from "chai";
 import * as fs from "fs-extra";
 
 import TestUtil from "../TestUtil";
-import removeProjectCmd from "../../command/project/RemoveProjectCmd";
 
 import { testProjects } from "./Creation.test";
 
@@ -37,7 +36,7 @@ describe(`Project removal wrapper`, function() {
 
                     projectPath = project.localPath.fsPath;
 
-                    await removeProjectCmd(project, true);
+                    await project.deleteFromConnection(true);
 
                     await TestUtil.waitForCondition(this, {
                         label: `Waiting for ${project.name} to be removed from ${project.connection.label}`,
@@ -56,7 +55,7 @@ describe(`Project removal wrapper`, function() {
 
                     await TestUtil.waitForCondition(this, {
                         label: `Waiting for ${project.name} to be removed from the VS Code workspace`,
-                        condition: async () => !(project.workspaceFolder == null),
+                        condition: async () => project.workspaceFolder != null,
                     });
                 });
             });


### PR DESCRIPTION
Pls rebase and merge

```
commit 8bab7eeb4572d1a0dde794de992770e899ce96a5 (HEAD -> fixRemoveProject, origin/fixRemoveProject)
Author: Tim Etchells <timetchells@ibm.com>
Date:   Thu May 7 14:17:04 2020 -0400

    Fix case where the last ws folder is being removed
    
    Signed-off-by: Tim Etchells <timetchells@ibm.com>

commit 78e3b390a8f7b02bff595b92aa1ee105a5333c8e
Author: Tim Etchells <timetchells@ibm.com>
Date:   Wed May 6 18:23:49 2020 -0400

    Fix project removal behaviour, again
    
    - Remove workspace folder before attempting to delete files
        - Fixes https://github.com/eclipse/codewind/issues/2456
    - Add a warning message if the extension is going to reload due to a workspace folder change
    
    Signed-off-by: Tim Etchells <timetchells@ibm.com>
```
## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
