### PR TITLE
Improve discoverability of project logs

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -113,6 +113,12 @@
                         "default": true,
                         "scope": "application"
                     },
+                    "codewind.automaticallyShowLogsAfterCreation": {
+                        "description": "%configDescr_automaticallyShowLogsAfterCreation%",
+                        "type": "boolean",
+                        "default": true,
+                        "scope": "application"
+                    },
                     "codewind.alwaysCreateProjectsInWorkspace": {
                         "description": "%configDescr_alwaysCreateProjectsInWorkspace%",
                         "type": "boolean",

--- a/dev/package.nls.json
+++ b/dev/package.nls.json
@@ -7,6 +7,7 @@
     "configTitle": "Codewind",
     "configDescr_autoShowView": "Automatically expand the Codewind view after opening a Codewind project.",
     "configDescr_overviewOnCreation": "Open the Project Overview page after creating or adding a new Codewind project.",
+    "configDescr_automaticallyShowLogsAfterCreation": "Automatically open a new project's build and application logs as they become available.",
     "configDescr_alwaysCreateProjectsInWorkspace": "Create new Codewind projects under the VS Code workspace. If the workspace has multiple root folders, the workspace folder must be selected.",
     "configDescr_addNewProjectsToWorkspace": "When a new Codewind project is created outside of the VS Code workspace, add the project to the workspace.",
     "configDescr_showHomepage": "Show the Codewind Homepage when the extension is started.",

--- a/dev/res/css/project-overview.css
+++ b/dev/res/css/project-overview.css
@@ -1,5 +1,5 @@
 body {
-    max-width: 1000px;
+    max-width: 800px;
     min-width: 600px;
     padding-left: 1%;
     padding-right: 1%;
@@ -81,7 +81,7 @@ td {
 }
 
 .btn-cell input[type="image"] {
-    height: 1.5em;
+    height: 1.75em;
     margin: 0;
     padding: 0;
     margin-left: 1em;

--- a/dev/res/img/dark/filter.svg
+++ b/dev/res/img/dark/filter.svg
@@ -1,0 +1,7 @@
+<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="32" height="32"
+    viewBox="0 0 32 32" aria-hidden="true">
+    <path fill="#fff"
+        d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z">
+    </path>
+    <title>Filter</title>
+</svg>

--- a/dev/res/img/light/filter.svg
+++ b/dev/res/img/light/filter.svg
@@ -1,0 +1,7 @@
+<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="32" height="32"
+    viewBox="0 0 32 32" aria-hidden="true">
+    <path fill="#000"
+        d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z">
+    </path>
+    <title>Filter</title>
+</svg>

--- a/dev/src/codewind/project/Project.ts
+++ b/dev/src/codewind/project/Project.ts
@@ -291,9 +291,9 @@ export default class Project implements vscode.QuickPickItem {
 
     /**
      * Call when this project's mutable fields change
-     * to update the tree view and project info pages.
+     * to update the tree view and project info page.
      */
-    private onChange(): void {
+    public onChange(): void {
         this.connection.onChange(this);
         this._overviewPage?.refresh();
     }

--- a/dev/src/command/CommandUtil.ts
+++ b/dev/src/command/CommandUtil.ts
@@ -24,7 +24,7 @@ import projectOverviewCmd from "./project/ProjectOverviewCmd";
 import toggleAutoBuildCmd from "./project/ToggleAutoBuildCmd";
 import openMetricsDashboardCmd from "./project/OpenMetricsDashboard";
 import { refreshConnectionCmd, refreshLocalCWCmd } from "./connection/RefreshConnectionCmd";
-import { manageLogs, showAllLogs, hideAllLogs } from "./project/ManageLogsCmd";
+import { manageLogs } from "./project/ManageLogsCmd";
 import createProjectCmd from "./connection/CreateUserProjectCmd";
 import bindProjectCmd from "./connection/BindProjectCmd";
 import openPerformanceDashboard from "./project/OpenPerfDashboard";
@@ -116,9 +116,9 @@ export function createCommands(): vscode.Disposable[] {
         registerProjectCommand(Commands.RESTART_RUN, restartProjectCmd, [ false ], ProjectState.getAppStateSet("started-starting")),
         registerProjectCommand(Commands.RESTART_DEBUG, restartProjectCmd, [ true ], ProjectState.getAppStateSet("started-starting")),
 
-        registerProjectCommand(Commands.MANAGE_LOGS, manageLogs, [], ProjectState.getAppStateSet("enabled")),
-        registerProjectCommand(Commands.SHOW_ALL_LOGS, showAllLogs, [], ProjectState.getAppStateSet("enabled")),
-        registerProjectCommand(Commands.HIDE_ALL_LOGS, hideAllLogs, [], ProjectState.getAppStateSet("enabled")),
+        registerProjectCommand(Commands.MANAGE_LOGS,    manageLogs, [], ProjectState.getAppStateSet("enabled")),
+        registerProjectCommand(Commands.SHOW_ALL_LOGS,  manageLogs, [ "show" ], ProjectState.getAppStateSet("enabled")),
+        registerProjectCommand(Commands.HIDE_ALL_LOGS,  manageLogs, [ "hide" ], ProjectState.getAppStateSet("enabled")),
 
         registerProjectCommand(Commands.ENABLE_PROJECT, toggleEnablementCmd, [], ProjectState.getAppStateSet("disabled")),
         registerProjectCommand(Commands.DISABLE_PROJECT, toggleEnablementCmd, [], ProjectState.getAppStateSet("enabled")),

--- a/dev/src/constants/CWImages.ts
+++ b/dev/src/constants/CWImages.ts
@@ -105,6 +105,7 @@ export const ThemedImages = {
     Copy:   new CWImage(true, "copy"),
     Error:  new CWImage(true, "error"),
     Edit:   new CWImage(true, "edit"),
+    Filter: new CWImage(true, "filter"),
     Help:   new CWImage(true, "help"),
     Info:   new CWImage(true, "info"),
     New:    new CWImage(true, "new"),

--- a/dev/src/constants/Commands.ts
+++ b/dev/src/constants/Commands.ts
@@ -78,6 +78,7 @@ enum Commands {
     VSC_REVEAL_EXPLORER = "revealInExplorer",
     VSC_FOCUS_PROBLEMS = "workbench.action.problems.focus",
     VSC_CMD_PALETTE = "workbench.action.showCommands",
+    VSC_OPEN_SETTINGS = "workbench.action.openSettings",
 }
 
 export default Commands;

--- a/dev/src/constants/Configurations.ts
+++ b/dev/src/constants/Configurations.ts
@@ -12,6 +12,8 @@
 import * as vscode from "vscode";
 
 import Log from "../Logger";
+import Commands from "./Commands";
+import MCUtil from "../MCUtil";
 
 const CONFIG_SECTION = "codewind";
 
@@ -22,8 +24,6 @@ class CWConfiguration<T> {
     /**
      *
      * @param subsection Must match `contributes.configuration.properties` in package.json
-     * @param defaultValue
-     * @param scope
      */
     constructor(
         private readonly subsection: string,
@@ -48,12 +48,28 @@ class CWConfiguration<T> {
 
         Log.d(`Set ${this.subsection} to ${newValue}`);
     }
+
+    /**
+     * Open the Preferences UI to this configuration's section.
+     */
+    public async openUI(): Promise<void> {
+        try {
+            Log.d(`Open settings to ${this.fullSection}`)
+            await vscode.commands.executeCommand(Commands.VSC_OPEN_SETTINGS, this.fullSection);
+        }
+        catch (err) {
+            const errMsg = `Error opening VS Code settings to ${this.fullSection}`;
+            Log.e(errMsg, err);
+            vscode.window.showErrorMessage(`${errMsg}: ${MCUtil.errToString(err)}`)
+        }
+    }
 }
 
 export const CWConfigurations = {
     SHOW_HOMEPAGE:                  new CWConfiguration("showHomePage", true, vscode.ConfigurationTarget.Global),
     AUTO_SHOW_VIEW:                 new CWConfiguration("autoShowView", true, vscode.ConfigurationTarget.Global),
     OVERVIEW_ON_CREATION:           new CWConfiguration("openOverviewOnCreation", true, vscode.ConfigurationTarget.Global),
+    LOGS_ON_CREATION:               new CWConfiguration("automaticallyShowLogsAfterCreation", true, vscode.ConfigurationTarget.Global),
 
     ALWAYS_CREATE_IN_WORKSPACE:     new CWConfiguration("alwaysCreateProjectsInWorkspace", true, vscode.ConfigurationTarget.Workspace),
     ADD_NEW_PROJECTS_TO_WORKSPACE:  new CWConfiguration("addNewProjectsToWorkspace", true, vscode.ConfigurationTarget.Workspace),

--- a/dev/vsce-package.js
+++ b/dev/vsce-package.js
@@ -37,7 +37,6 @@ const che_cmdsToDelete = [
     "attachDebugger",
     "restartRun",
     "restartDebug",
-    "manageLogs",
     "containerShell",
     "separator",
     "addProjectToWorkspace",


### PR DESCRIPTION
- Add preference (true by default) to show a new project's logs as they become available
- Add logs list to project overview page and allow opening & managing from there
- Fix some logic that resulted in uncessarily refreshing logs that were already open
- Manage Logs now works in Theia
- Resolves https://github.com/eclipse/codewind/issues/2755

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
