### PR TITLE
Add support for 'outgoing' project links

### DIFF
--- a/dev/res/css/project-overview.css
+++ b/dev/res/css/project-overview.css
@@ -3,6 +3,7 @@ body {
     /* min-width: 600px; */
     width: 800px;
     --section-spacing: 1em;
+    --create-link-btn-width: 20ch;
 }
 
 #btns-section {
@@ -104,16 +105,14 @@ body {
 }
 
 .btn-cell {
-    width: 1%;
-    /* display: inline-flex; */
-    /* align-items: center; */
+    width: 3em;
 }
 
 .btn-cell input[type="image"] {
     height: 1.75em;
     margin: 0;
     padding: 0;
-    margin-left: 1em;
+    /* margin-left: 1em; */
     vertical-align: middle;
 }
 
@@ -145,10 +144,12 @@ body {
 
 #create-link-btn {
     margin-left: auto;
+    width: var(--create-link-btn-width);
 }
 
 .link-table {
     border-collapse: collapse;
+    margin-bottom: 3em;
 }
 
 .link-table tr {
@@ -169,8 +170,8 @@ body {
     width: 64ch;
 }
 
-.btn-col {
-    width: 3em;
+#spacer-col {
+    width: var(--create-link-btn-width);
 }
 
 thead td {

--- a/dev/src/codewind/Types.ts
+++ b/dev/src/codewind/Types.ts
@@ -198,6 +198,11 @@ export interface ProjectLink {
     // projectURL: string;
 }
 
+export interface ProjectOutgoingLink extends ProjectLink {
+    otherProjectID: string;
+    otherProjectName: string;
+}
+
 /**
  * Project data as
  * - returned by /api/v1/projects

--- a/dev/src/command/project/RemoveProjectCmd.ts
+++ b/dev/src/command/project/RemoveProjectCmd.ts
@@ -22,14 +22,25 @@ import CWExtensionContext from "../../CWExtensionContext";
 export default async function removeProjectCmd(project: Project): Promise<void> {
     let deleteFiles: boolean;
 
-    // confirm deletion
-    const deleteMsg = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteProjectMsg", {
-        projectName: project.name,
-        connectionLabel: project.connection.label
-    });
+    let confirmDeletePrompt;
+    if (project.outgoingLinks.length > 0) {
+        const outgoingLinksList = MCUtil.joinList(project.outgoingLinks.map((link) => link.otherProjectName), "and");
+        confirmDeletePrompt = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteProjectWithLinksMsg", {
+            projectName: project.name,
+            connectionLabel: project.connection.label,
+            outgoingLinksList,
+        });
+    }
+    else {
+        confirmDeletePrompt = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteProjectMsg", {
+            projectName: project.name,
+            connectionLabel: project.connection.label
+        });
+    }
+
     const deleteBtn = Translator.t(StringNamespaces.CMD_MISC, "confirmDeleteBtn", { projectName: project.name });
 
-    const deleteRes = await vscode.window.showInformationMessage(deleteMsg, { modal: true }, deleteBtn);
+    const deleteRes = await vscode.window.showInformationMessage(confirmDeletePrompt, { modal: true }, deleteBtn);
     if (deleteRes !== deleteBtn) {
         // cancelled
         return;

--- a/dev/src/command/webview/ProjectOverviewPageWrapper.ts
+++ b/dev/src/command/webview/ProjectOverviewPageWrapper.ts
@@ -37,7 +37,7 @@ export enum ProjectOverviewWVMessages {
     TOGGLE_INJECT_METRICS = "toggleInjectMetrics",
     MANAGE_LOGS = "manageLogs",
     OPEN_LOG = "openLog",
-    OPEN_PROJECT = "openProject",
+    OPEN_PROJECT_LINKS = "openProject",
     CREATE_LINK = "createLink",
     EDIT_LINK = "editLink",
     REMOVE_LINK = "removeLink",
@@ -124,7 +124,7 @@ export default class ProjectOverviewPageWrapper extends WebviewWrapper {
                 }
                 break;
             }
-            case ProjectOverviewWVMessages.OPEN_PROJECT: {
+            case ProjectOverviewWVMessages.OPEN_PROJECT_LINKS: {
                 const projectID = msg.data as string;
                 const project = await this.project.connection.getProjectByID(projectID);
                 if (project == null) {
@@ -133,7 +133,7 @@ export default class ProjectOverviewPageWrapper extends WebviewWrapper {
                     vscode.window.showErrorMessage(errMsg);
                     return;
                 }
-                await projectOverviewCmd(project);
+                await projectOverviewCmd(project, true);
                 break;
             }
             case ProjectOverviewWVMessages.CREATE_LINK: {

--- a/dev/translations/en.json
+++ b/dev/translations/en.json
@@ -22,6 +22,7 @@
         "noContainerForShell": "{{ projectName }} does not have an application {{ podOrContainer }} running. Wait until the project is Running.",
         "alreadyInCodewindWorkspace": "The Codewind workspace is already your workspace root.",
         "confirmDeleteProjectMsg": "Are you sure you want to remove {{ projectName }} from {{ connectionLabel }}?",
+        "confirmDeleteProjectWithLinksMsg": "Are you sure you want to remove {{ projectName }} from {{ connectionLabel }}?\n\n{{ projectName }} has a link to {{ outgoingLinksList }}. Any environment variables which reference {{ projectName }} will have to be removed.",
         "confirmDeleteBtn": "Remove Project",
         "alsoDeleteDirMsg": "{{ projectName }} will be removed from {{ connectionLabel }}.\nDo you also want to delete {{- dirPath }} from your disk?\nClick {{ cancelBtn }} to keep the directory.",
         "alsoDeleteDirBtn": "Delete Directory",


### PR DESCRIPTION
Now links both 'to' and 'from' the project are available in the Overview page
If a project that is linked to is removed, a warning is shown

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
